### PR TITLE
perf: NI + router performance observers (telemetry, non-intrusive)

### DIFF
--- a/c_model/include/axi/axi_master.hpp
+++ b/c_model/include/axi/axi_master.hpp
@@ -87,6 +87,19 @@ struct ReadResult {
     std::size_t scenario_line;
 };
 
+// IssueInfo is fired once per transaction on the first AW/AR handshake.
+// Carries the original scenario_txn geometry so observers can record
+// issue time and correlate with the matching WriteResult/ReadResult.
+struct IssueInfo {
+    bool is_write;
+    uint8_t id;
+    std::size_t scenario_line;
+    uint64_t addr;
+    uint8_t size;
+    uint8_t len;
+    Burst burst;
+};
+
 // SFINAE helper: call slave.force_aw_not_pending() only if the slave type
 // provides that method (WireSlavePort does; NullSlavePort, AxiSlave do not).
 // Used by the fault-injection path to clear stale AW-pending state so that
@@ -155,10 +168,10 @@ class AxiMasterT {
                 // WriteResult carries the ORIGINAL user txn (addr, size, len, burst)
                 // — NOT sub-burst geometry. The scoreboard re-derives per-beat addr
                 // from the original txn.
-                if (wcb_)
-                    wcb_(WriteResult{op.src_txn.addr, op.src_txn.size, op.src_txn.len,
-                                     op.src_txn.burst, op.src_txn.lock, op.data, op.strb_per_beat,
-                                     op.worst_resp_, b->id, op.src_txn.scenario_line});
+                for (auto& cb : wcb_)
+                    cb(WriteResult{op.src_txn.addr, op.src_txn.size, op.src_txn.len,
+                                   op.src_txn.burst, op.src_txn.lock, op.data, op.strb_per_beat,
+                                   op.worst_resp_, b->id, op.src_txn.scenario_line});
                 deq.pop_front();
                 --active_write_count_;
                 if (deq.empty()) active_write_ops_.erase(b->id);
@@ -221,10 +234,10 @@ class AxiMasterT {
                     read_dump_ << '\n';
                 }
                 read_dump_.flush();
-                if (rcb_)
-                    rcb_(ReadResult{op.src_txn.addr, op.src_txn.size, op.src_txn.len,
-                                    op.src_txn.burst, op.read_accumulator, op.worst_resp_, r->id,
-                                    op.src_txn.scenario_line});
+                for (auto& cb : rcb_)
+                    cb(ReadResult{op.src_txn.addr, op.src_txn.size, op.src_txn.len,
+                                  op.src_txn.burst, op.read_accumulator, op.worst_resp_, r->id,
+                                  op.src_txn.scenario_line});
                 deq.pop_front();
                 --active_read_count_;
                 if (deq.empty()) active_read_ops_.erase(r->id);
@@ -305,8 +318,18 @@ class AxiMasterT {
     std::size_t active_write_count() const { return active_write_count_; }
     std::size_t active_read_count() const { return active_read_count_; }
 
-    void on_write_completed(std::function<void(const WriteResult&)> cb) { wcb_ = std::move(cb); }
-    void on_read_observed(std::function<void(const ReadResult&)> cb) { rcb_ = std::move(cb); }
+    void on_write_completed(std::function<void(const WriteResult&)> cb) {
+        wcb_.push_back(std::move(cb));
+    }
+    void on_read_observed(std::function<void(const ReadResult&)> cb) {
+        rcb_.push_back(std::move(cb));
+    }
+    void on_write_issued(std::function<void(const IssueInfo&)> cb) {
+        iwcb_.push_back(std::move(cb));
+    }
+    void on_read_issued(std::function<void(const IssueInfo&)> cb) {
+        ircb_.push_back(std::move(cb));
+    }
 
     // Fault injection: call once after construction to arm a specific violation.
     // When inject.mode == None (default), tick() adds one bool check — no other
@@ -432,8 +455,13 @@ class AxiMasterT {
                     clear_aw_pending_if_supported(slave_);
                     return op.write_request_done();
                 }
+                const bool first_aw = (op.next_aw_sub_idx_ == 0);
                 if (!slave_.push_aw(aw)) return op.write_request_done();
                 ++op.next_aw_sub_idx_;
+                if (first_aw)
+                    for (auto& cb : iwcb_)
+                        cb(IssueInfo{true, id, op.src_txn.scenario_line, op.src_txn.addr,
+                                     op.src_txn.size, op.src_txn.len, op.src_txn.burst});
             }
             const std::size_t bpb = 1ull << sub.size;
             while (op.w_pushed_in_cur_ <= sub.len) {
@@ -484,8 +512,13 @@ class AxiMasterT {
             // Phase C: wire-through scenario_txn.lock onto AR.lock (1-bit).
             ar.lock = (op.src_txn.lock == LockType::Exclusive) ? 1u : 0u;
             ar.qos = op.src_txn.qos;
+            const bool first_ar = (op.next_ar_sub_idx_ == 0);
             if (!slave_.push_ar(ar)) return op.read_request_done();
             ++op.next_ar_sub_idx_;
+            if (first_ar)
+                for (auto& cb : ircb_)
+                    cb(IssueInfo{false, id, op.src_txn.scenario_line, op.src_txn.addr,
+                                 op.src_txn.size, op.src_txn.len, op.src_txn.burst});
         }
         return op.read_request_done();
     }
@@ -495,8 +528,10 @@ class AxiMasterT {
     std::size_t max_out_w_, max_out_r_;
     std::size_t next_txn_idx_ = 0;
     std::ofstream read_dump_;
-    std::function<void(const WriteResult&)> wcb_;
-    std::function<void(const ReadResult&)> rcb_;
+    std::vector<std::function<void(const WriteResult&)>> wcb_;
+    std::vector<std::function<void(const ReadResult&)>> rcb_;
+    std::vector<std::function<void(const IssueInfo&)>> iwcb_;
+    std::vector<std::function<void(const IssueInfo&)>> ircb_;
     // Per-AXI-ID FIFO of outstanding ops (post AXI4 conformity fix — same-id
     // concurrent allowed). AXI4 IHI 0022 §A5.3: responses for same id complete
     // in submission order; per-id deque preserves submission order; B/R routing
@@ -639,19 +674,19 @@ struct WireSlavePort {
 
   private:
     bool awready_ = false;
-    bool wready_  = false;
+    bool wready_ = false;
     bool arready_ = false;
     bool w_delivered_this_tick_ = false;  // beta-tick: max 1 W beat per tick
 
-    bool    aw_pending_ = false;
-    AwBeat  last_aw_{};
-    bool    w_pending_  = false;
-    WBeat   last_w_{};
-    bool    ar_pending_ = false;
-    ArBeat  last_ar_{};
+    bool aw_pending_ = false;
+    AwBeat last_aw_{};
+    bool w_pending_ = false;
+    WBeat last_w_{};
+    bool ar_pending_ = false;
+    ArBeat last_ar_{};
 
-    std::deque<BBeat>  b_queue_;
-    std::deque<RBeat>  r_queue_;
+    std::deque<BBeat> b_queue_;
+    std::deque<RBeat> r_queue_;
 };
 
 }  // namespace detail
@@ -673,8 +708,8 @@ class AxiMasterStandalone {
   public:
     explicit AxiMasterStandalone(AxiMasterConfig cfg)
         : wire_slave_(),
-          inner_(cfg.scenario_yaml, wire_slave_, cfg.read_dump_path,
-                 cfg.max_outstanding_write, cfg.max_outstanding_read) {}
+          inner_(cfg.scenario_yaml, wire_slave_, cfg.read_dump_path, cfg.max_outstanding_write,
+                 cfg.max_outstanding_read) {}
 
     void tick() { inner_.tick(); }
     bool done() const { return inner_.done(); }

--- a/c_model/include/axi/axi_master.hpp
+++ b/c_model/include/axi/axi_master.hpp
@@ -702,6 +702,8 @@ struct AxiMasterConfig {
 // AxiMasterStandalone owns a WireSlavePort and wraps AxiMasterT<WireSlavePort>.
 // Exposes the same public API as AxiMasterT: tick(), done(), on_write_completed(),
 // on_read_observed(), active_write_count(), active_read_count().
+// Note: on_write_issued()/on_read_issued() exist on AxiMasterT but are intentionally
+// not forwarded here (cosim path does not need them).
 // wire_port() gives ShellAdapter direct access to drain request beats and
 // inject response beats on each DPI tick.
 class AxiMasterStandalone {

--- a/c_model/include/nmu/rob.hpp
+++ b/c_model/include/nmu/rob.hpp
@@ -75,6 +75,21 @@ class Rob : public RequestPacketizer, public ResponseDepacketizer {
         drain_observer_ = std::move(cb);
     }
 
+    // Test introspection: current outstanding-entry count summed over all ids.
+    // Counts the Disabled-mode per-id `outstanding` deques (the mode the c_model
+    // runs this round). Enabled-mode slot-pool occupancy (write_entries_) is not
+    // counted -- extend here if/when Enabled mode is exercised.
+    std::size_t write_occupancy() const {
+        std::size_t n = 0;
+        for (const auto& s : write_) n += s.outstanding.size();
+        return n;
+    }
+    std::size_t read_occupancy() const {
+        std::size_t n = 0;
+        for (const auto& s : read_) n += s.outstanding.size();
+        return n;
+    }
+
   private:
     std::function<void(bool, uint8_t)> drain_observer_;
     void notify_drained(bool is_write, uint8_t id) {

--- a/c_model/include/noc/router.hpp
+++ b/c_model/include/noc/router.hpp
@@ -123,6 +123,16 @@ class Router {
         return input_fifo_[port][vc].size();
     }
     std::size_t output_fifo_size(std::size_t port) const { return output_fifo_[port].size(); }
+    uint8_t num_vc() const { return cfg_.num_vc; }
+    // Front flit's routed output port for (in_port, vc), or nullopt if empty.
+    // Pure read; mirrors stage-2's route check without side effects.
+    std::optional<RouterPort> front_route(std::size_t in_port, uint8_t vc) const {
+        if (in_port >= ROUTER_PORT_COUNT || vc >= cfg_.num_vc) return std::nullopt;
+        const auto& q = input_fifo_[in_port][vc];
+        if (q.empty()) return std::nullopt;
+        const auto dst = static_cast<uint8_t>(q.front().get_header_field("dst_id"));
+        return route_compute(dst, cfg_);
+    }
 
   private:
     struct InputAdapter : RouterLink {

--- a/c_model/tests/common/CMakeLists.txt
+++ b/c_model/tests/common/CMakeLists.txt
@@ -38,3 +38,7 @@ target_link_libraries(test_axi_master_callbacks PRIVATE yaml-cpp::yaml-cpp)
 add_cmodel_test(test_ni_perf_observer)
 target_include_directories(test_ni_perf_observer PRIVATE
   ${CMAKE_CURRENT_SOURCE_DIR}/..)
+
+add_cmodel_test(test_router_perf_observer)
+target_include_directories(test_router_perf_observer PRIVATE
+  ${CMAKE_CURRENT_SOURCE_DIR}/..)

--- a/c_model/tests/common/CMakeLists.txt
+++ b/c_model/tests/common/CMakeLists.txt
@@ -42,3 +42,7 @@ target_include_directories(test_ni_perf_observer PRIVATE
 add_cmodel_test(test_router_perf_observer)
 target_include_directories(test_router_perf_observer PRIVATE
   ${CMAKE_CURRENT_SOURCE_DIR}/..)
+
+add_cmodel_test(test_perf_report)
+target_include_directories(test_perf_report PRIVATE
+  ${CMAKE_CURRENT_SOURCE_DIR}/..)

--- a/c_model/tests/common/CMakeLists.txt
+++ b/c_model/tests/common/CMakeLists.txt
@@ -34,3 +34,7 @@ add_cmodel_test(test_axi_master_callbacks)
 target_include_directories(test_axi_master_callbacks PRIVATE
   ${CMAKE_CURRENT_SOURCE_DIR}/..)
 target_link_libraries(test_axi_master_callbacks PRIVATE yaml-cpp::yaml-cpp)
+
+add_cmodel_test(test_ni_perf_observer)
+target_include_directories(test_ni_perf_observer PRIVATE
+  ${CMAKE_CURRENT_SOURCE_DIR}/..)

--- a/c_model/tests/common/CMakeLists.txt
+++ b/c_model/tests/common/CMakeLists.txt
@@ -29,3 +29,8 @@ target_include_directories(test_perf_stats PRIVATE
 add_cmodel_test(test_perf_phase)
 target_include_directories(test_perf_phase PRIVATE
   ${CMAKE_CURRENT_SOURCE_DIR}/..)
+
+add_cmodel_test(test_axi_master_callbacks)
+target_include_directories(test_axi_master_callbacks PRIVATE
+  ${CMAKE_CURRENT_SOURCE_DIR}/..)
+target_link_libraries(test_axi_master_callbacks PRIVATE yaml-cpp::yaml-cpp)

--- a/c_model/tests/common/CMakeLists.txt
+++ b/c_model/tests/common/CMakeLists.txt
@@ -25,3 +25,7 @@ target_include_directories(test_narrow_io PRIVATE
 add_cmodel_test(test_perf_stats)
 target_include_directories(test_perf_stats PRIVATE
   ${CMAKE_CURRENT_SOURCE_DIR}/..)
+
+add_cmodel_test(test_perf_phase)
+target_include_directories(test_perf_phase PRIVATE
+  ${CMAKE_CURRENT_SOURCE_DIR}/..)

--- a/c_model/tests/common/CMakeLists.txt
+++ b/c_model/tests/common/CMakeLists.txt
@@ -21,3 +21,7 @@ target_include_directories(test_channel_model_per_vc_credit PRIVATE
 add_cmodel_test(test_narrow_io)
 target_include_directories(test_narrow_io PRIVATE
   ${CMAKE_CURRENT_SOURCE_DIR}/..)
+
+add_cmodel_test(test_perf_stats)
+target_include_directories(test_perf_stats PRIVATE
+  ${CMAKE_CURRENT_SOURCE_DIR}/..)

--- a/c_model/tests/common/ni_perf_observer.hpp
+++ b/c_model/tests/common/ni_perf_observer.hpp
@@ -1,0 +1,88 @@
+#pragma once
+#include "common/perf_common.hpp"
+#include "common/perf_stats.hpp"
+#include <cstddef>
+#include <cstdint>
+#include <functional>
+#include <map>
+#include <string>
+#include <utility>
+
+namespace ni::cmodel::testing {
+
+struct NIPerfConfig {
+    std::string flow_label = "NI";
+    StatsConfig latency_stats{};  // thresholds when NOC_PERF=1, else empty
+    StatsConfig occupancy_stats{};
+};
+
+// NI-edge observer. Driven by AxiMaster issue/completion callbacks (template-free:
+// the harness forwards them) plus a per-cycle sample() polling a RoB-occupancy
+// probe. Latency keyed by scenario_line within ONE NMU (one instance per NMU).
+class NIPerfObserver {
+  public:
+    NIPerfObserver(const uint64_t& now, PhaseController& phase,
+                   std::function<std::size_t()> rob_occupancy_probe, NIPerfConfig cfg)
+        : now_(now),
+          phase_(phase),
+          rob_probe_(std::move(rob_occupancy_probe)),
+          cfg_(std::move(cfg)),
+          wr_lat_(cfg_.latency_stats),
+          rd_lat_(cfg_.latency_stats),
+          outstanding_(cfg_.occupancy_stats),
+          rob_occ_(cfg_.occupancy_stats) {}
+
+    void on_issue(bool is_write, std::size_t line) {
+        auto& m = is_write ? wr_inflight_ : rd_inflight_;
+        m[line] = InFlight{now_, phase_.phase() == Phase::Measurement};
+        if (is_write)
+            ++w_out_;
+        else
+            ++r_out_;
+        const std::size_t cur = w_out_ + r_out_;
+        if (cur > out_peak_) out_peak_ = cur;
+    }
+    void on_complete(bool is_write, std::size_t line) {
+        auto& m = is_write ? wr_inflight_ : rd_inflight_;
+        auto it = m.find(line);
+        if (it != m.end()) {
+            if (it->second.eligible)
+                (is_write ? wr_lat_ : rd_lat_).add(now_ - it->second.issue_cycle);
+            m.erase(it);
+        }
+        if (is_write) {
+            if (w_out_) --w_out_;
+        } else {
+            if (r_out_) --r_out_;
+        }
+    }
+    // Called once per cycle by the harness, AFTER component ticks.
+    void sample() {
+        if (phase_.phase() != Phase::Measurement) return;
+        outstanding_.add(w_out_ + r_out_);
+        rob_occ_.add(rob_probe_ ? rob_probe_() : 0);
+    }
+
+    const std::string& label() const { return cfg_.flow_label; }
+    const Stats& write_latency() const { return wr_lat_; }
+    const Stats& read_latency() const { return rd_lat_; }
+    const Stats& outstanding() const { return outstanding_; }
+    const Stats& rob_occupancy() const { return rob_occ_; }
+    std::size_t outstanding_peak() const { return out_peak_; }
+    std::size_t stuck_count() const { return wr_inflight_.size() + rd_inflight_.size(); }
+
+  private:
+    struct InFlight {
+        uint64_t issue_cycle;
+        bool eligible;
+    };
+    const uint64_t& now_;
+    PhaseController& phase_;
+    std::function<std::size_t()> rob_probe_;
+    NIPerfConfig cfg_;
+    Stats wr_lat_, rd_lat_, outstanding_, rob_occ_;
+    std::map<std::size_t, InFlight> wr_inflight_, rd_inflight_;
+    std::size_t w_out_ = 0, r_out_ = 0, out_peak_ = 0;
+};
+
+}  // namespace ni::cmodel::testing

--- a/c_model/tests/common/perf_common.hpp
+++ b/c_model/tests/common/perf_common.hpp
@@ -1,0 +1,30 @@
+#pragma once
+#include <cstdint>
+
+namespace ni::cmodel::testing {
+
+enum class Phase { Warmup, Measurement, Drain };
+
+struct PhaseConfig {
+    uint64_t warmup_cycles = 0;
+};
+
+// Three-phase gating bound to the harness cycle counter by const reference.
+// Drain is one-way: begin_drain() is called once when all masters report done().
+class PhaseController {
+  public:
+    PhaseController(const uint64_t& now, PhaseConfig cfg) : now_(now), cfg_(cfg) {}
+    void begin_drain() { draining_ = true; }
+    Phase phase() const {
+        if (draining_) return Phase::Drain;
+        if (now_ < cfg_.warmup_cycles) return Phase::Warmup;
+        return Phase::Measurement;
+    }
+
+  private:
+    const uint64_t& now_;
+    PhaseConfig cfg_;
+    bool draining_ = false;
+};
+
+}  // namespace ni::cmodel::testing

--- a/c_model/tests/common/perf_report.hpp
+++ b/c_model/tests/common/perf_report.hpp
@@ -1,0 +1,98 @@
+#pragma once
+#include "common/ni_perf_observer.hpp"
+#include "common/router_perf_observer.hpp"
+#include <cstdlib>
+#include <fstream>
+#include <iostream>
+#include <ostream>
+#include <string>
+#include <vector>
+
+namespace ni::cmodel::testing {
+
+// Aggregates NI + Router observers. Always prints a scalar stdout summary;
+// writes a JSON file only under NOC_PERF=1.
+class PerfReport {
+  public:
+    void add_ni(const NIPerfObserver* ni) { ni_.push_back(ni); }
+    void add_router(const RouterPerfObserver* r) { router_ = r; }
+
+    void write_summary(std::ostream& os) const {
+        for (const auto* ni : ni_) {
+            os << "[perf:" << ni->label() << "] "
+               << "wr_lat(min/mean/max)=" << ni->write_latency().min() << '/'
+               << ni->write_latency().mean() << '/' << ni->write_latency().max() << ' '
+               << "rd_lat(min/mean/max)=" << ni->read_latency().min() << '/'
+               << ni->read_latency().mean() << '/' << ni->read_latency().max() << ' '
+               << "outstanding_peak=" << ni->outstanding_peak() << ' '
+               << "rob_occ_peak=" << ni->rob_occupancy().max() << ' '
+               << "stuck=" << ni->stuck_count() << '\n';
+        }
+        if (router_) {
+            os << "[perf:ROUTER] credit_stall_cycles=" << router_->credit_stall_cycles() << '\n';
+        }
+    }
+
+    // Always summary; JSON only under NOC_PERF=1.
+    void emit(const std::string& run_label) const {
+        write_summary(std::cout);
+        const char* g = std::getenv("NOC_PERF");
+        if (!g || std::string(g) != "1") return;
+        const char* f = std::getenv("NOC_PERF_FILE");
+        const std::string path = f ? std::string(f) : ("perf_" + run_label + ".json");
+        std::ofstream js(path);
+        if (js) write_json(js);
+    }
+
+    void write_json(std::ostream& os) const {
+        os << "{\"ni\":[";
+        for (std::size_t i = 0; i < ni_.size(); ++i) {
+            const auto* ni = ni_[i];
+            if (i) os << ',';
+            os << "{\"label\":\"" << ni->label() << "\","
+               << "\"write_latency\":" << stat_json(ni->write_latency()) << ','
+               << "\"read_latency\":" << stat_json(ni->read_latency()) << ','
+               << "\"outstanding_peak\":" << ni->outstanding_peak() << ','
+               << "\"outstanding\":" << stat_json(ni->outstanding()) << ','
+               << "\"rob_occupancy\":" << stat_json(ni->rob_occupancy()) << '}';
+        }
+        os << "],\"router\":{";
+        if (router_) {
+            os << "\"credit_stall_cycles\":" << router_->credit_stall_cycles()
+               << ",\"per_router\":[";
+            for (std::size_t i = 0; i < router_->router_count(); ++i) {
+                if (i) os << ',';
+                os << "{\"label\":\"" << router_->label(i) << "\","
+                   << "\"stall\":" << router_->stall(i) << ','
+                   << "\"in_fifo\":" << stat_json(router_->in_fifo(i)) << ','
+                   << "\"out_fifo\":" << stat_json(router_->out_fifo(i)) << '}';
+            }
+            os << ']';
+        } else {
+            os << "\"credit_stall_cycles\":0";
+        }
+        os << "}}";
+    }
+
+  private:
+    static std::string stat_json(const Stats& s) {
+        std::string o =
+            "{\"count\":" + std::to_string(s.count()) + ",\"min\":" + std::to_string(s.min()) +
+            ",\"max\":" + std::to_string(s.max()) + ",\"mean\":" + std::to_string(s.mean()) +
+            ",\"variance\":" + std::to_string(s.variance());
+        if (!s.histogram().empty()) {
+            o += ",\"histogram\":{\"thresholds\":[";
+            for (std::size_t i = 0; i < s.thresholds().size(); ++i)
+                o += (i ? "," : "") + std::to_string(s.thresholds()[i]);
+            o += "],\"bins\":[";
+            for (std::size_t i = 0; i < s.histogram().size(); ++i)
+                o += (i ? "," : "") + std::to_string(s.histogram()[i]);
+            o += "]}";
+        }
+        return o + "}";
+    }
+    std::vector<const NIPerfObserver*> ni_;
+    const RouterPerfObserver* router_ = nullptr;
+};
+
+}  // namespace ni::cmodel::testing

--- a/c_model/tests/common/perf_stats.hpp
+++ b/c_model/tests/common/perf_stats.hpp
@@ -1,0 +1,59 @@
+#pragma once
+#include <cstddef>
+#include <cstdint>
+#include <limits>
+#include <utility>
+#include <vector>
+
+namespace ni::cmodel::testing {
+
+struct StatsConfig {
+    std::vector<uint64_t> bin_thresholds;  // ascending; empty = scalars only
+};
+
+// One metric's accumulator: count/sum/min/max + optional threshold-bin histogram.
+// Histogram is maintained only when bin_thresholds is non-empty (NOC_PERF gate).
+class Stats {
+  public:
+    explicit Stats(StatsConfig cfg) : thresholds_(std::move(cfg.bin_thresholds)) {
+        if (!thresholds_.empty()) bins_.assign(thresholds_.size() + 1, 0);
+    }
+    void add(uint64_t v) {
+        ++count_;
+        sum_ += v;
+        sumsq_ += v * v;
+        if (v < min_) min_ = v;
+        if (v > max_) max_ = v;
+        if (!thresholds_.empty()) ++bins_[bin_index_(v)];
+    }
+    uint64_t count() const { return count_; }
+    uint64_t sum() const { return sum_; }
+    uint64_t min() const { return count_ ? min_ : 0; }
+    uint64_t max() const { return count_ ? max_ : 0; }
+    double mean() const {
+        return count_ ? static_cast<double>(sum_) / static_cast<double>(count_) : 0.0;
+    }
+    double variance() const {
+        if (!count_) return 0.0;
+        const double m = mean();
+        return static_cast<double>(sumsq_) / static_cast<double>(count_) - m * m;
+    }
+    const std::vector<uint64_t>& thresholds() const { return thresholds_; }
+    const std::vector<uint64_t>& histogram() const { return bins_; }
+
+  private:
+    std::size_t bin_index_(uint64_t v) const {
+        for (std::size_t i = 0; i < thresholds_.size(); ++i)
+            if (v < thresholds_[i]) return i;
+        return thresholds_.size();
+    }
+    std::vector<uint64_t> thresholds_;
+    std::vector<uint64_t> bins_;
+    uint64_t count_ = 0;
+    uint64_t sum_ = 0;
+    uint64_t sumsq_ = 0;
+    uint64_t min_ = std::numeric_limits<uint64_t>::max();
+    uint64_t max_ = 0;
+};
+
+}  // namespace ni::cmodel::testing

--- a/c_model/tests/common/router_perf_observer.hpp
+++ b/c_model/tests/common/router_perf_observer.hpp
@@ -1,0 +1,88 @@
+#pragma once
+#include "common/perf_common.hpp"
+#include "common/perf_stats.hpp"
+#include "noc/router.hpp"
+#include <cstddef>
+#include <cstdint>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace ni::cmodel::testing {
+
+struct ObservedRouter {
+    std::string label;
+    const noc::Router* router;
+};
+
+struct RouterPerfConfig {
+    StatsConfig occupancy_stats{};  // thresholds when NOC_PERF=1, else empty
+};
+
+// Polls a set of Routers once per cycle (after their tick). Credit-stall =
+// a (in_port, vc) front flit routed to output p with credit(p,vc)==0.
+class RouterPerfObserver {
+  public:
+    RouterPerfObserver(const uint64_t& now, PhaseController& phase,
+                       std::vector<ObservedRouter> routers, RouterPerfConfig cfg)
+        : now_(now), phase_(phase), routers_(std::move(routers)), cfg_(std::move(cfg)) {
+        per_router_.reserve(routers_.size());
+        for (const auto& r : routers_) per_router_.push_back(PerRouter{cfg_.occupancy_stats});
+    }
+
+    void sample() {
+        (void)now_;
+        if (phase_.phase() != Phase::Measurement) return;
+        for (std::size_t ri = 0; ri < routers_.size(); ++ri) {
+            const noc::Router& r = *routers_[ri].router;
+            PerRouter& pr = per_router_[ri];
+            const uint8_t nvc = r.num_vc();
+            for (std::size_t in = 0; in < noc::ROUTER_PORT_COUNT; ++in) {
+                for (uint8_t vc = 0; vc < nvc; ++vc) {
+                    auto out = r.front_route(in, vc);
+                    if (out && r.credit(static_cast<std::size_t>(*out), vc) == 0) {
+                        ++credit_stall_cycles_;
+                        ++pr.stall;
+                    }
+                    pr.in_fifo.add(r.input_fifo_size(in, vc));
+                }
+            }
+            for (std::size_t p = 0; p < noc::ROUTER_PORT_COUNT; ++p) {
+                pr.out_fifo.add(r.output_fifo_size(p));
+                ++pr.out_cycles[p];
+                if (r.output_fifo_size(p) > 0) ++pr.out_nonempty[p];
+            }
+        }
+    }
+
+    std::size_t credit_stall_cycles() const { return credit_stall_cycles_; }
+    std::size_t router_count() const { return routers_.size(); }
+    const std::string& label(std::size_t i) const { return routers_[i].label; }
+    double out_nonempty_ratio(std::size_t i, std::size_t port) const {
+        const auto& pr = per_router_[i];
+        return pr.out_cycles[port] ? static_cast<double>(pr.out_nonempty[port]) /
+                                         static_cast<double>(pr.out_cycles[port])
+                                   : 0.0;
+    }
+    const Stats& in_fifo(std::size_t i) const { return per_router_[i].in_fifo; }
+    const Stats& out_fifo(std::size_t i) const { return per_router_[i].out_fifo; }
+    std::size_t stall(std::size_t i) const { return per_router_[i].stall; }
+
+  private:
+    struct PerRouter {
+        explicit PerRouter(StatsConfig c) : in_fifo(c), out_fifo(c) {}
+        Stats in_fifo;
+        Stats out_fifo;
+        std::size_t stall = 0;
+        std::size_t out_cycles[noc::ROUTER_PORT_COUNT] = {};
+        std::size_t out_nonempty[noc::ROUTER_PORT_COUNT] = {};
+    };
+    const uint64_t& now_;
+    PhaseController& phase_;
+    std::vector<ObservedRouter> routers_;
+    RouterPerfConfig cfg_;
+    std::vector<PerRouter> per_router_;
+    std::size_t credit_stall_cycles_ = 0;
+};
+
+}  // namespace ni::cmodel::testing

--- a/c_model/tests/common/test_axi_master_callbacks.cpp
+++ b/c_model/tests/common/test_axi_master_callbacks.cpp
@@ -1,0 +1,85 @@
+#include "axi/axi_master.hpp"
+#include "axi/axi_slave.hpp"
+#include "axi/memory.hpp"
+#include "axi/scenario_parser.hpp"
+#include <gtest/gtest.h>
+#include <fstream>
+#include <string>
+#include <vector>
+
+namespace axi = ni::cmodel::axi;
+
+namespace {
+// Minimal single-write + single-read scenario, 1 beat, 1 byte.
+// The parser requires data_file for write ops and dump_file for read ops;
+// schema_version is omitted (non-strict mode) to avoid metadata regex checks.
+std::string write_inline_scenario() {
+    const std::string dir = std::string(::testing::TempDir()) + "/cb_scn";
+    const std::string data_path = dir + ".data";
+    const std::string dump_path = dir + ".rdump";
+    const std::string yaml_path = dir + ".yaml";
+
+    std::ofstream(data_path) << "AA\n";
+    {
+        std::ofstream dummy(dump_path);
+    }  // create empty placeholder for read dump
+
+    std::ofstream yf(yaml_path);
+    yf << "transactions:\n"
+       << "  - op: write\n"
+       << "    id: 0\n"
+       << "    addr: 0\n"
+       << "    size: 0\n"
+       << "    len: 0\n"
+       << "    burst: INCR\n"
+       << "    data_file: " << data_path << "\n"
+       << "    strb_file: \"\"\n"
+       << "  - op: read\n"
+       << "    id: 0\n"
+       << "    addr: 0\n"
+       << "    size: 0\n"
+       << "    len: 0\n"
+       << "    burst: INCR\n"
+       << "    dump_file: " << dump_path << "\n";
+
+    return yaml_path;
+}
+}  // namespace
+
+TEST(AxiMasterCallbacks, FanoutAndIssueBeforeCompletion) {
+    const std::string scn = write_inline_scenario();
+    axi::Memory mem(/*base=*/0, /*size=*/4096, /*write_latency_ticks=*/0,
+                    /*read_latency_ticks=*/0);
+    axi::AxiSlave slave(mem);
+    // axi::AxiMaster = AxiMasterT<AxiSlave> (axi_master.hpp:520). 3rd arg is the
+    // read-dump path (the master opens it on construction).
+    axi::AxiMaster master(scn, slave, std::string(::testing::TempDir()) + "/cb.read.txt",
+                          /*max_out_w=*/1, /*max_out_r=*/1);
+
+    int wc1 = 0, wc2 = 0, w_issue = 0;
+    std::size_t issue_line = 999, complete_line = 888;
+    bool issue_seen_before_complete = false;
+
+    master.on_write_issued([&](const axi::IssueInfo& ii) {
+        ++w_issue;
+        issue_line = ii.scenario_line;
+    });
+    master.on_write_completed([&](const axi::WriteResult& wr) {
+        ++wc1;
+        complete_line = wr.scenario_line;
+        issue_seen_before_complete = (w_issue == 1);
+    });
+    master.on_write_completed([&](const axi::WriteResult&) { ++wc2; });
+
+    for (int cycle = 0; cycle < 200 && !master.done(); ++cycle) {
+        master.tick();
+        slave.tick();
+        mem.tick();
+    }
+    ASSERT_TRUE(master.done());
+    EXPECT_EQ(wc1, 1);  // first subscriber fired
+    EXPECT_EQ(wc2, 1);  // second subscriber fired (H1: not overwritten)
+    EXPECT_EQ(w_issue, 1);
+    EXPECT_TRUE(issue_seen_before_complete);
+    EXPECT_EQ(issue_line, complete_line);
+}

--- a/c_model/tests/common/test_ni_perf_observer.cpp
+++ b/c_model/tests/common/test_ni_perf_observer.cpp
@@ -1,0 +1,68 @@
+#include "common/ni_perf_observer.hpp"
+#include "common/perf_common.hpp"
+#include <gtest/gtest.h>
+
+using ni::cmodel::testing::NIPerfConfig;
+using ni::cmodel::testing::NIPerfObserver;
+using ni::cmodel::testing::PhaseConfig;
+using ni::cmodel::testing::PhaseController;
+
+TEST(NIPerfObserver, LatencyAndOutstandingPeak) {
+    uint64_t now = 0;
+    PhaseController phase(now, PhaseConfig{});  // measurement from cycle 0
+    std::size_t fake_rob = 0;
+    NIPerfObserver obs(now, phase, [&] { return fake_rob; }, NIPerfConfig{"NI"});
+
+    now = 5;
+    obs.on_issue(/*is_write=*/true, /*line=*/1);  // w outstanding=1
+    now = 6;
+    obs.on_issue(true, 2);  // w outstanding=2 (peak)
+    now = 10;
+    obs.on_complete(true, 1);  // latency 10-5=5
+    now = 12;
+    obs.on_complete(true, 2);  // latency 12-6=6
+
+    EXPECT_EQ(obs.outstanding_peak(), 2u);
+    EXPECT_EQ(obs.write_latency().count(), 2u);
+    EXPECT_EQ(obs.write_latency().min(), 5u);
+    EXPECT_EQ(obs.write_latency().max(), 6u);
+    EXPECT_EQ(obs.stuck_count(), 0u);
+}
+
+TEST(NIPerfObserver, WarmupIssuedNotCountedButOutstandingBalances) {
+    uint64_t now = 0;
+    PhaseController phase(now, PhaseConfig{/*warmup_cycles=*/10});
+    NIPerfObserver obs(now, phase, [] { return std::size_t{0}; }, NIPerfConfig{"NI"});
+
+    now = 2;
+    obs.on_issue(true, 1);  // issued in Warmup -> not eligible
+    now = 15;
+    obs.on_complete(true, 1);                    // completes in Measurement
+    EXPECT_EQ(obs.write_latency().count(), 0u);  // not recorded
+    EXPECT_EQ(obs.stuck_count(), 0u);            // outstanding still balanced
+}
+
+TEST(NIPerfObserver, StuckTransactionSurfaced) {
+    uint64_t now = 0;
+    PhaseController phase(now, PhaseConfig{});
+    NIPerfObserver obs(now, phase, [] { return std::size_t{0}; }, NIPerfConfig{"NI"});
+    now = 1;
+    obs.on_issue(false, 7);  // read issued, never completed
+    EXPECT_EQ(obs.stuck_count(), 1u);
+}
+
+// H4: a transaction issued during Measurement but completing during Drain is
+// still recorded, because eligibility is latched at issue, not re-checked at
+// completion.
+TEST(NIPerfObserver, MeasurementIssuedDrainCompletedStillRecorded) {
+    uint64_t now = 0;
+    PhaseController phase(now, PhaseConfig{});  // measurement from cycle 0
+    NIPerfObserver obs(now, phase, [] { return std::size_t{0}; }, NIPerfConfig{"NI"});
+    now = 3;
+    obs.on_issue(true, 1);  // issued in Measurement -> eligible latched
+    phase.begin_drain();    // now draining
+    now = 9;
+    obs.on_complete(true, 1);                    // completes in Drain
+    EXPECT_EQ(obs.write_latency().count(), 1u);  // still recorded
+    EXPECT_EQ(obs.write_latency().max(), 6u);    // 9 - 3
+}

--- a/c_model/tests/common/test_perf_phase.cpp
+++ b/c_model/tests/common/test_perf_phase.cpp
@@ -1,0 +1,27 @@
+#include "common/perf_common.hpp"
+#include <gtest/gtest.h>
+
+using ni::cmodel::testing::Phase;
+using ni::cmodel::testing::PhaseConfig;
+using ni::cmodel::testing::PhaseController;
+
+TEST(PerfPhase, WarmupThenMeasurementThenDrain) {
+    uint64_t now = 0;
+    PhaseController p(now, PhaseConfig{/*warmup_cycles=*/3});
+    now = 0;
+    EXPECT_EQ(p.phase(), Phase::Warmup);
+    now = 2;
+    EXPECT_EQ(p.phase(), Phase::Warmup);
+    now = 3;
+    EXPECT_EQ(p.phase(), Phase::Measurement);
+    now = 9;
+    EXPECT_EQ(p.phase(), Phase::Measurement);
+    p.begin_drain();
+    EXPECT_EQ(p.phase(), Phase::Drain);
+}
+
+TEST(PerfPhase, ZeroWarmupStartsInMeasurement) {
+    uint64_t now = 0;
+    PhaseController p(now, PhaseConfig{});  // warmup_cycles=0
+    EXPECT_EQ(p.phase(), Phase::Measurement);
+}

--- a/c_model/tests/common/test_perf_report.cpp
+++ b/c_model/tests/common/test_perf_report.cpp
@@ -1,0 +1,26 @@
+#include "common/ni_perf_observer.hpp"
+#include "common/perf_report.hpp"
+#include "common/perf_common.hpp"
+#include <gtest/gtest.h>
+#include <sstream>
+#include <string>
+
+using namespace ni::cmodel::testing;
+
+TEST(PerfReport, SummaryLineContainsLabels) {
+    uint64_t now = 0;
+    PhaseController phase(now, PhaseConfig{});
+    NIPerfObserver ni(now, phase, [] { return std::size_t{0}; }, NIPerfConfig{"flowA"});
+    now = 1;
+    ni.on_issue(true, 1);
+    now = 4;
+    ni.on_complete(true, 1);
+
+    std::ostringstream os;
+    PerfReport rep;
+    rep.add_ni(&ni);
+    rep.write_summary(os);
+    const std::string out = os.str();
+    EXPECT_NE(out.find("[perf:flowA]"), std::string::npos);
+    EXPECT_NE(out.find("wr_lat"), std::string::npos);
+}

--- a/c_model/tests/common/test_perf_stats.cpp
+++ b/c_model/tests/common/test_perf_stats.cpp
@@ -22,6 +22,7 @@ TEST(PerfStats, EmptyIsSafe) {
     EXPECT_EQ(s.min(), 0u);
     EXPECT_EQ(s.max(), 0u);
     EXPECT_DOUBLE_EQ(s.mean(), 0.0);  // no div-by-zero
+    EXPECT_DOUBLE_EQ(s.variance(), 0.0);
 }
 
 TEST(PerfStats, ThresholdBinsCountCorrectly) {

--- a/c_model/tests/common/test_perf_stats.cpp
+++ b/c_model/tests/common/test_perf_stats.cpp
@@ -1,0 +1,35 @@
+#include "common/perf_stats.hpp"
+#include <gtest/gtest.h>
+
+using ni::cmodel::testing::Stats;
+using ni::cmodel::testing::StatsConfig;
+
+TEST(PerfStats, ScalarsOverKnownSequence) {
+    Stats s(StatsConfig{});  // no histogram
+    for (uint64_t v : {2u, 4u, 6u, 8u}) s.add(v);
+    EXPECT_EQ(s.count(), 4u);
+    EXPECT_EQ(s.sum(), 20u);
+    EXPECT_EQ(s.min(), 2u);
+    EXPECT_EQ(s.max(), 8u);
+    EXPECT_DOUBLE_EQ(s.mean(), 5.0);
+    EXPECT_DOUBLE_EQ(s.variance(), 5.0);  // ((9+1+1+9)/4) = 5
+    EXPECT_TRUE(s.histogram().empty());
+}
+
+TEST(PerfStats, EmptyIsSafe) {
+    Stats s(StatsConfig{});
+    EXPECT_EQ(s.count(), 0u);
+    EXPECT_EQ(s.min(), 0u);
+    EXPECT_EQ(s.max(), 0u);
+    EXPECT_DOUBLE_EQ(s.mean(), 0.0);  // no div-by-zero
+}
+
+TEST(PerfStats, ThresholdBinsCountCorrectly) {
+    // thresholds {10,20}: bin0=[0,10) bin1=[10,20) bin2=[20,inf)
+    Stats s(StatsConfig{{10, 20}});
+    for (uint64_t v : {5u, 9u, 10u, 15u, 20u, 99u}) s.add(v);
+    ASSERT_EQ(s.histogram().size(), 3u);
+    EXPECT_EQ(s.histogram()[0], 2u);  // 5,9
+    EXPECT_EQ(s.histogram()[1], 2u);  // 10,15
+    EXPECT_EQ(s.histogram()[2], 2u);  // 20,99
+}

--- a/c_model/tests/common/test_router_perf_observer.cpp
+++ b/c_model/tests/common/test_router_perf_observer.cpp
@@ -1,0 +1,66 @@
+#include "common/router_perf_observer.hpp"
+#include "common/perf_common.hpp"
+#include "noc/router.hpp"
+#include "flit.hpp"
+#include <gtest/gtest.h>
+
+namespace noc = ni::cmodel::noc;
+using ni::cmodel::Flit;
+using ni::cmodel::testing::PhaseConfig;
+using ni::cmodel::testing::PhaseController;
+using ni::cmodel::testing::RouterPerfConfig;
+using ni::cmodel::testing::RouterPerfObserver;
+
+static Flit make_flit(uint8_t dst_id) {
+    Flit f;
+    f.set_header_field("dst_id", dst_id);
+    f.set_header_field("vc_id", 0);
+    f.set_header_field("axi_ch", 0);
+    f.set_header_field("last", 1);
+    return f;
+}
+
+TEST(RouterPerfObserver, IdleRouterZeroStall) {
+    noc::RouterConfig c;
+    c.x = 0;
+    c.y = 0;
+    c.mesh_x_dim = 2;
+    c.mesh_y_dim = 1;
+    c.num_vc = 1;
+    noc::Router r(c);
+    uint64_t now = 0;
+    PhaseController phase(now, PhaseConfig{});
+    RouterPerfObserver obs(now, phase, {{"req0", &r}}, RouterPerfConfig{});
+    obs.sample();
+    EXPECT_EQ(obs.credit_stall_cycles(), 0u);
+}
+
+TEST(RouterPerfObserver, FrontFlitNoCreditAccruesStall) {
+    // Deterministic stall: vc_depth=1, output_fifo_depth=1, EAST has no
+    // downstream wired. flit1 consumes the single EAST credit (1->0) and parks
+    // in the output FIFO (stage-3 finds no downstream, so no credit return).
+    // flit2 then sits in the input FIFO routed EAST with credit(EAST,0)==0.
+    noc::RouterConfig c;
+    c.x = 0;
+    c.y = 0;
+    c.mesh_x_dim = 2;
+    c.mesh_y_dim = 1;
+    c.num_vc = 1;
+    c.vc_depth = 1;
+    c.output_fifo_depth = 1;
+    noc::Router r(c);
+    const auto LOCAL = static_cast<std::size_t>(noc::RouterPort::LOCAL);
+
+    r.input(LOCAL).push_flit(make_flit(0x01));  // flit1, dst (1,0) -> EAST
+    r.tick();                                   // stage1: flit1 landing -> input FIFO
+    r.tick();  // stage2: flit1 granted, EAST credit 1->0, parks in output FIFO
+
+    uint64_t now = 0;
+    PhaseController phase(now, PhaseConfig{});
+    RouterPerfObserver obs(now, phase, {{"req0", &r}}, RouterPerfConfig{});
+
+    r.input(LOCAL).push_flit(make_flit(0x01));  // flit2, dst EAST
+    r.tick();  // flit2 -> input FIFO; cannot be granted (credit(EAST,0)==0)
+    obs.sample();
+    EXPECT_GT(obs.credit_stall_cycles(), 0u);
+}

--- a/c_model/tests/integration/test_router_loopback.cpp
+++ b/c_model/tests/integration/test_router_loopback.cpp
@@ -35,6 +35,9 @@
 #include "nsu/port_params.hpp"
 #include "scenario_helpers.hpp"
 #include "common/scenario.hpp"
+#include "common/ni_perf_observer.hpp"
+#include "common/perf_common.hpp"
+#include "common/router_perf_observer.hpp"
 #include <array>
 #include <cstddef>
 #include <cstdint>
@@ -132,7 +135,8 @@ struct Flow {
                ch.nsu_rsp_out(slave_node)),
           master_(yaml_path, nmu_.axi_slave_port(), read_dump, sc_.config.max_outstanding_write,
                   sc_.config.max_outstanding_read),
-          expected_dst_(expected_dst) {
+          expected_dst_(expected_dst),
+          master_node_(master_node) {
         slave_.set_memory_bounds(sc_.config.memory_base, sc_.config.memory_size);
         master_.on_write_completed([this](const axi::WriteResult& wr) {
             sb_.handle_write_completed(wr, wr.data, wr.strb_per_beat);
@@ -233,6 +237,11 @@ struct Flow {
     bool done() const { return master_.done(); }
     std::size_t mismatches() const { return sb_.mismatch_count(); }
 
+    // Observer wiring accessors.
+    axi::AxiMasterT<nmu::AxiSlavePort>& master() { return master_; }
+    const nmu::Rob& rob() const { return nmu_.rob(); }
+    uint8_t node_index() const { return static_cast<uint8_t>(master_node_); }
+
   private:
     static nmu::NmuConfig make_nmu_cfg(std::size_t num_vc, std::size_t node) {
         nmu::NmuConfig cfg{};
@@ -265,6 +274,7 @@ struct Flow {
     axi::AxiMasterT<nmu::AxiSlavePort> master_;
     axi::Scoreboard sb_;
     uint8_t expected_dst_;
+    std::size_t master_node_;
 
     std::deque<axi::BBeat> b_holdover_;
     std::deque<axi::RBeat> r_holdover_;
@@ -317,3 +327,90 @@ INSTANTIATE_TEST_SUITE_P(NumVc, RouterLoopbackParam, ::testing::Values(1, 2, 4, 
                          [](const ::testing::TestParamInfo<std::size_t>& info) {
                              return "vc" + std::to_string(info.param);
                          });
+
+// ---------------------------------------------------------------------------
+// Non-intrusive A/B test: observers must not perturb cycle-to-completion.
+// Runs the bidirectional num_vc=1 fabric twice (plain, then with observers
+// attached) and asserts identical cycle count and zero-mismatch scoreboards.
+// ---------------------------------------------------------------------------
+
+namespace {
+
+std::size_t run_loopback(bool with_observers, std::size_t* stall_out) {
+    using namespace ni::cmodel::testing;
+    const std::size_t num_vc = 1;
+    TwoNodeFabric ch(static_cast<uint8_t>(num_vc));
+    const std::string base = scenario_path("AX4-BAS-003_single_write_read_aligned");
+    const std::string tmp = std::string(::testing::TempDir());
+    Flow flow_a(ch, /*master_node=*/1, /*slave_node=*/0, base, num_vc, tmp + "/ab_a.read.txt",
+                /*dst=*/0x00);
+    const std::string yaml_b = shifted_scenario_path(base, 0x100000000, /*tag=*/42);
+    Flow flow_b(ch, /*master_node=*/0, /*slave_node=*/1, yaml_b, num_vc, tmp + "/ab_b.read.txt",
+                /*dst=*/0x01);
+
+    uint64_t now = 0;
+    PhaseController phase(now, PhaseConfig{});
+    NIPerfObserver ni_a(
+        now, phase, [&] { return flow_a.rob().write_occupancy() + flow_a.rob().read_occupancy(); },
+        NIPerfConfig{"A"});
+    NIPerfObserver ni_b(
+        now, phase, [&] { return flow_b.rob().write_occupancy() + flow_b.rob().read_occupancy(); },
+        NIPerfConfig{"B"});
+    RouterPerfObserver router_obs(now, phase,
+                                  {{"req0", &ch.req_router(0)},
+                                   {"req1", &ch.req_router(1)},
+                                   {"rsp0", &ch.rsp_router(0)},
+                                   {"rsp1", &ch.rsp_router(1)}},
+                                  RouterPerfConfig{});
+
+    if (with_observers) {
+        flow_a.master().on_write_issued(
+            [&](const axi::IssueInfo& i) { ni_a.on_issue(true, i.scenario_line); });
+        flow_a.master().on_read_issued(
+            [&](const axi::IssueInfo& i) { ni_a.on_issue(false, i.scenario_line); });
+        flow_a.master().on_write_completed(
+            [&](const axi::WriteResult& w) { ni_a.on_complete(true, w.scenario_line); });
+        flow_a.master().on_read_observed(
+            [&](const axi::ReadResult& r) { ni_a.on_complete(false, r.scenario_line); });
+        flow_b.master().on_write_issued(
+            [&](const axi::IssueInfo& i) { ni_b.on_issue(true, i.scenario_line); });
+        flow_b.master().on_read_issued(
+            [&](const axi::IssueInfo& i) { ni_b.on_issue(false, i.scenario_line); });
+        flow_b.master().on_write_completed(
+            [&](const axi::WriteResult& w) { ni_b.on_complete(true, w.scenario_line); });
+        flow_b.master().on_read_observed(
+            [&](const axi::ReadResult& r) { ni_b.on_complete(false, r.scenario_line); });
+    }
+
+    std::size_t cycle = 0;
+    const std::size_t cap = 100000;
+    while ((!flow_a.done() || !flow_b.done()) && cycle < cap) {
+        now = cycle;
+        flow_a.pre_tick();
+        flow_b.pre_tick();
+        ch.tick();
+        flow_a.post_tick();
+        flow_b.post_tick();
+        if (with_observers) {
+            ni_a.sample();
+            ni_b.sample();
+            router_obs.sample();
+        }
+        ++cycle;
+    }
+    if (with_observers && (flow_a.done() && flow_b.done())) phase.begin_drain();
+    if (stall_out) *stall_out = router_obs.credit_stall_cycles();
+    EXPECT_EQ(flow_a.mismatches(), 0u);
+    EXPECT_EQ(flow_b.mismatches(), 0u);
+    return cycle;
+}
+
+}  // namespace
+
+TEST(RouterLoopbackPerf, ObserversAreNonIntrusive) {
+    std::size_t stall = 0;
+    const std::size_t plain = run_loopback(/*with_observers=*/false, nullptr);
+    const std::size_t obs = run_loopback(/*with_observers=*/true, &stall);
+    EXPECT_EQ(plain, obs) << "attaching observers changed cycle-to-completion (plain=" << plain
+                          << " obs=" << obs << ")";
+}

--- a/c_model/tests/nmu/CMakeLists.txt
+++ b/c_model/tests/nmu/CMakeLists.txt
@@ -45,3 +45,8 @@ add_cmodel_test(test_nmu_credit)
 target_include_directories(test_nmu_credit PRIVATE
   ${CMAKE_CURRENT_SOURCE_DIR}/..)
 target_link_libraries(test_nmu_credit PRIVATE yaml-cpp::yaml-cpp)
+
+add_cmodel_test(test_rob_occupancy)
+target_include_directories(test_rob_occupancy PRIVATE
+  ${CMAKE_CURRENT_SOURCE_DIR}/..)
+target_link_libraries(test_rob_occupancy PRIVATE yaml-cpp::yaml-cpp)

--- a/c_model/tests/nmu/test_rob_occupancy.cpp
+++ b/c_model/tests/nmu/test_rob_occupancy.cpp
@@ -1,0 +1,33 @@
+#include "axi/types.hpp"
+#include "nmu/nmu.hpp"
+#include <gtest/gtest.h>
+
+namespace nmu = ni::cmodel::nmu;
+namespace axi = ni::cmodel::axi;
+
+// Empty RoB reports zero occupancy; after one AW is accepted and forwarded
+// (push_aw queues in the port; tick() forwards it into the RoB) the write
+// occupancy is non-zero. With no B response arriving (null rsp stub) the
+// outstanding entry persists, so occupancy stays > 0.
+TEST(RobOccupancy, EmptyThenNonZeroAfterAw) {
+    nmu::NmuConfig cfg;  // defaults
+    // NmuConfig{} zero-initializes PortParams queue depths; must set non-zero
+    // values for push_aw to be accepted (depth=0 means queue full immediately).
+    cfg.port_params.aw_queue_depth = 4;
+    cfg.port_params.w_queue_depth = 4;
+    cfg.port_params.ar_queue_depth = 4;
+    cfg.port_params.b_queue_depth = 4;
+    cfg.port_params.r_queue_depth = 4;
+    cfg.port_params.depkt_b_q_depth = 4;
+    cfg.port_params.depkt_r_q_depth = 4;
+    nmu::NmuStandalone n(cfg);
+    EXPECT_EQ(n.rob().write_occupancy(), 0u);
+    EXPECT_EQ(n.rob().read_occupancy(), 0u);
+
+    axi::AwBeat aw{/*id=*/0,         /*addr=*/0x1000, /*len=*/0,  /*size=*/5,
+                   axi::Burst::INCR, /*cache=*/0xA,   /*lock=*/0, /*prot=*/0x3,
+                   /*region=*/0xF,   /*user=*/0x55,   /*qos=*/0xC};
+    ASSERT_TRUE(n.axi_slave_port().push_aw(aw));
+    n.tick();  // port forwards AW into the RoB
+    EXPECT_GT(n.rob().write_occupancy(), 0u);
+}

--- a/c_model/tests/noc/CMakeLists.txt
+++ b/c_model/tests/noc/CMakeLists.txt
@@ -8,3 +8,7 @@ target_include_directories(test_router PRIVATE
 
 add_cmodel_test(test_router_adapters)
 target_include_directories(test_router_adapters PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/..)
+
+add_cmodel_test(test_router_front_route)
+target_include_directories(test_router_front_route PRIVATE
+  ${CMAKE_CURRENT_SOURCE_DIR}/..)

--- a/c_model/tests/noc/test_router_front_route.cpp
+++ b/c_model/tests/noc/test_router_front_route.cpp
@@ -1,0 +1,43 @@
+#include "noc/router.hpp"
+#include "flit.hpp"
+#include <gtest/gtest.h>
+
+namespace noc = ni::cmodel::noc;
+using ni::cmodel::Flit;
+
+static Flit make_flit(uint8_t dst_id, uint8_t vc) {
+    Flit f;
+    f.set_header_field("dst_id", dst_id);
+    f.set_header_field("vc_id", vc);
+    f.set_header_field("axi_ch", 0);
+    f.set_header_field("last", 1);
+    return f;
+}
+
+TEST(RouterFrontRoute, EmptyReturnsNullopt) {
+    noc::RouterConfig c;
+    c.x = 0;
+    c.y = 0;
+    c.mesh_x_dim = 2;
+    c.mesh_y_dim = 1;
+    c.num_vc = 1;
+    noc::Router r(c);
+    EXPECT_EQ(r.num_vc(), 1u);
+    EXPECT_FALSE(r.front_route(static_cast<std::size_t>(noc::RouterPort::LOCAL), 0).has_value());
+}
+
+TEST(RouterFrontRoute, FrontFlitRoutesEast) {
+    noc::RouterConfig c;
+    c.x = 0;
+    c.y = 0;
+    c.mesh_x_dim = 2;
+    c.mesh_y_dim = 1;
+    c.num_vc = 1;
+    noc::Router r(c);
+    r.input(static_cast<std::size_t>(noc::RouterPort::LOCAL))
+        .push_flit(make_flit(/*dst=(1,0)*/ 0x01, 0));
+    r.tick();  // landing -> input FIFO
+    auto out = r.front_route(static_cast<std::size_t>(noc::RouterPort::LOCAL), 0);
+    ASSERT_TRUE(out.has_value());
+    EXPECT_EQ(*out, noc::RouterPort::EAST);
+}

--- a/docs/superpowers/plans/2026-06-17-ni-router-perf-observer.md
+++ b/docs/superpowers/plans/2026-06-17-ni-router-perf-observer.md
@@ -62,6 +62,7 @@ TEST(PerfStats, ScalarsOverKnownSequence) {
     EXPECT_EQ(s.min(), 2u);
     EXPECT_EQ(s.max(), 8u);
     EXPECT_DOUBLE_EQ(s.mean(), 5.0);
+    EXPECT_DOUBLE_EQ(s.variance(), 5.0);  // ((9+1+1+9)/4) = 5
     EXPECT_TRUE(s.histogram().empty());
 }
 
@@ -125,6 +126,7 @@ class Stats {
     void add(uint64_t v) {
         ++count_;
         sum_ += v;
+        sumsq_ += v * v;
         if (v < min_) min_ = v;
         if (v > max_) max_ = v;
         if (!thresholds_.empty()) ++bins_[bin_index_(v)];
@@ -134,6 +136,11 @@ class Stats {
     uint64_t min() const { return count_ ? min_ : 0; }
     uint64_t max() const { return count_ ? max_ : 0; }
     double mean() const { return count_ ? static_cast<double>(sum_) / static_cast<double>(count_) : 0.0; }
+    double variance() const {
+        if (!count_) return 0.0;
+        const double m = mean();
+        return static_cast<double>(sumsq_) / static_cast<double>(count_) - m * m;
+    }
     const std::vector<uint64_t>& thresholds() const { return thresholds_; }
     const std::vector<uint64_t>& histogram() const { return bins_; }
 
@@ -147,6 +154,7 @@ class Stats {
     std::vector<uint64_t> bins_;
     uint64_t count_ = 0;
     uint64_t sum_ = 0;
+    uint64_t sumsq_ = 0;
     uint64_t min_ = std::numeric_limits<uint64_t>::max();
     uint64_t max_ = 0;
 };
@@ -315,9 +323,12 @@ std::string write_inline_scenario() {
 
 TEST(AxiMasterCallbacks, FanoutAndIssueBeforeCompletion) {
     const std::string scn = write_inline_scenario();
-    axi::Memory mem(/*base=*/0, /*size=*/4096);
+    axi::Memory mem(/*base=*/0, /*size=*/4096, /*write_latency_ticks=*/0, /*read_latency_ticks=*/0);
     axi::AxiSlave slave(mem);
-    axi::AxiMaster master(scn, slave, /*max_out_w=*/1, /*max_out_r=*/1);
+    // axi::AxiMaster = AxiMasterT<AxiSlave> (axi_master.hpp:520). 3rd arg is the
+    // read-dump path (the master opens it on construction).
+    axi::AxiMaster master(scn, slave, std::string(::testing::TempDir()) + "/cb.read.txt",
+                          /*max_out_w=*/1, /*max_out_r=*/1);
 
     int wc1 = 0, wc2 = 0, w_issue = 0;
     std::size_t issue_line = 999, complete_line = 888;
@@ -348,10 +359,12 @@ TEST(AxiMasterCallbacks, FanoutAndIssueBeforeCompletion) {
 }
 ```
 
-> Implementer note: the exact `AxiMaster` / `AxiSlave` / `Memory` ctor argument
-> order is whatever `test_test_logger.cpp` and `test_request_response_loopback.cpp`
-> already use; copy that construction verbatim if the signatures differ from the
-> sketch above. The assertions are the contract.
+> Implementer note: signatures are verified against `axi_master.hpp` /
+> `memory.hpp` (Memory takes base/size/write_latency_ticks/read_latency_ticks;
+> AxiMaster takes scenario/slave/read_dump_path/max_w/max_r). The inline YAML
+> field names must match `scenario_parser.hpp`; if the parser rejects a key,
+> align it with an existing `tests/scenarios/AX4-BAS-*/scenario.yaml`. The
+> assertions are the contract.
 
 - [ ] **Step 2: Register and run to verify it fails**
 
@@ -444,16 +457,13 @@ Fire the read issue callback on first-sub-burst AR accept. Replace lines 487-488
                                  op.src_txn.size, op.src_txn.len, op.src_txn.burst});
 ```
 
-In the non-template `AxiMaster` wrapper (the forwarding block around 683-688), add forwarders mirroring the existing `on_write_completed` forwarder:
-
-```cpp
-    void on_write_issued(std::function<void(const IssueInfo&)> cb) {
-        inner_.on_write_issued(std::move(cb));
-    }
-    void on_read_issued(std::function<void(const IssueInfo&)> cb) {
-        inner_.on_read_issued(std::move(cb));
-    }
-```
+The four `on_*` methods (including the two new `on_*_issued`) all live on the
+**`AxiMasterT` template** (registrars at 308-309). Both `using AxiMaster =
+AxiMasterT<AxiSlave>` (line 520, used by this test) and the loopback's
+`AxiMasterT<nmu::AxiSlavePort>` inherit them automatically -- no alias-level
+change needed. The `AxiMasterStandalone` cosim wrapper (683-688) is NOT in scope
+this round; forwarding `on_*_issued` there is optional follow-on for the cosim
+path and is omitted here.
 
 (`<functional>` and `<vector>` are already included via the existing callback members.)
 
@@ -472,7 +482,7 @@ git commit -m "feat(axi): multi-subscriber completion callbacks + on_*_issued is
 
 ---
 
-## Task 4: Rob occupancy getters (H? introspection)
+## Task 4: Rob occupancy getters (NI occupancy introspection, feeds NIPerfObserver)
 
 **Files:**
 - Modify: `c_model/include/nmu/rob.hpp` (public section, after `set_drain_observer` ~line 76; members `write_`/`read_` at 101-102)
@@ -536,6 +546,9 @@ In `c_model/include/nmu/rob.hpp`, in the public section (after `set_drain_observ
 
 ```cpp
     // Test introspection: current outstanding-entry count summed over all ids.
+    // Counts the Disabled-mode per-id `outstanding` deques (the mode the c_model
+    // runs this round). Enabled-mode slot-pool occupancy (write_entries_) is not
+    // counted -- extend here if/when Enabled mode is exercised.
     std::size_t write_occupancy() const {
         std::size_t n = 0;
         for (const auto& s : write_) n += s.outstanding.size();
@@ -715,6 +728,20 @@ TEST(NIPerfObserver, StuckTransactionSurfaced) {
     now = 1; obs.on_issue(false, 7);  // read issued, never completed
     EXPECT_EQ(obs.stuck_count(), 1u);
 }
+
+// H4: a transaction issued during Measurement but completing during Drain is
+// still recorded, because eligibility is latched at issue, not re-checked at
+// completion.
+TEST(NIPerfObserver, MeasurementIssuedDrainCompletedStillRecorded) {
+    uint64_t now = 0;
+    PhaseController phase(now, PhaseConfig{});  // measurement from cycle 0
+    NIPerfObserver obs(now, phase, [] { return std::size_t{0}; }, NIPerfConfig{"NI"});
+    now = 3; obs.on_issue(true, 1);    // issued in Measurement -> eligible latched
+    phase.begin_drain();               // now draining
+    now = 9; obs.on_complete(true, 1); // completes in Drain
+    EXPECT_EQ(obs.write_latency().count(), 1u);  // still recorded
+    EXPECT_EQ(obs.write_latency().max(), 6u);    // 9 - 3
+}
 ```
 
 - [ ] **Step 2: Register and run to verify it fails**
@@ -873,33 +900,29 @@ TEST(RouterPerfObserver, IdleRouterZeroStall) {
 }
 
 TEST(RouterPerfObserver, FrontFlitNoCreditAccruesStall) {
+    // Deterministic stall: vc_depth=1, output_fifo_depth=1, EAST has no
+    // downstream wired. flit1 consumes the single EAST credit (1->0) and parks
+    // in the output FIFO (stage-3 finds no downstream, so no credit return).
+    // flit2 then sits in the input FIFO routed EAST with credit(EAST,0)==0.
     noc::RouterConfig c; c.x = 0; c.y = 0; c.mesh_x_dim = 2; c.mesh_y_dim = 1;
     c.num_vc = 1; c.vc_depth = 1; c.output_fifo_depth = 1;
     noc::Router r(c);
-    // Drain EAST output credit to 0 by leaving no downstream: push enough flits
-    // routed EAST that the EAST output credit hits 0 while an input flit waits.
-    r.input(static_cast<std::size_t>(noc::RouterPort::LOCAL)).push_flit(make_flit(0x01));
-    r.tick();  // flit now in LOCAL input FIFO, routes EAST
-    // Force EAST credit to 0 via repeated grants with no credit return (no downstream set).
+    const auto LOCAL = static_cast<std::size_t>(noc::RouterPort::LOCAL);
+
+    r.input(LOCAL).push_flit(make_flit(0x01));  // flit1, dst (1,0) -> EAST
+    r.tick();  // stage1: flit1 landing -> input FIFO
+    r.tick();  // stage2: flit1 granted, EAST credit 1->0, parks in output FIFO
+
     uint64_t now = 0;
     PhaseController phase(now, PhaseConfig{});
     RouterPerfObserver obs(now, phase, {{"req0", &r}}, RouterPerfConfig{});
-    // Tick until EAST credit is exhausted, then a waiting front flit + credit==0 = stall.
-    for (int i = 0; i < 4; ++i) {
-        r.input(static_cast<std::size_t>(noc::RouterPort::LOCAL)).push_flit(make_flit(0x01));
-        r.tick();
-        now = static_cast<uint64_t>(i);
-        obs.sample();
-    }
+
+    r.input(LOCAL).push_flit(make_flit(0x01));  // flit2, dst EAST
+    r.tick();  // flit2 -> input FIFO; cannot be granted (credit(EAST,0)==0)
+    obs.sample();
     EXPECT_GT(obs.credit_stall_cycles(), 0u);
 }
 ```
-
-> Implementer note: if forcing `credit==0` through repeated grants proves
-> fiddly, instead construct the stall condition directly -- the contract is only
-> "front flit routed to an output whose `credit(out,vc)==0` accrues a stall
-> cycle; an idle router accrues zero." Use whatever minimal `Router` driving
-> sequence reaches `credit(EAST,0)==0` with a LOCAL-input flit routed EAST.
 
 - [ ] **Step 2: Register and run to verify it fails**
 
@@ -1135,10 +1158,24 @@ class PerfReport {
                << "\"write_latency\":" << stat_json(ni->write_latency()) << ','
                << "\"read_latency\":" << stat_json(ni->read_latency()) << ','
                << "\"outstanding_peak\":" << ni->outstanding_peak() << ','
+               << "\"outstanding\":" << stat_json(ni->outstanding()) << ','
                << "\"rob_occupancy\":" << stat_json(ni->rob_occupancy()) << '}';
         }
-        os << "],\"router\":{\"credit_stall_cycles\":"
-           << (router_ ? router_->credit_stall_cycles() : 0) << "}}";
+        os << "],\"router\":{";
+        if (router_) {
+            os << "\"credit_stall_cycles\":" << router_->credit_stall_cycles() << ",\"per_router\":[";
+            for (std::size_t i = 0; i < router_->router_count(); ++i) {
+                if (i) os << ',';
+                os << "{\"label\":\"" << router_->label(i) << "\","
+                   << "\"stall\":" << router_->stall(i) << ','
+                   << "\"in_fifo\":" << stat_json(router_->in_fifo(i)) << ','
+                   << "\"out_fifo\":" << stat_json(router_->out_fifo(i)) << '}';
+            }
+            os << ']';
+        } else {
+            os << "\"credit_stall_cycles\":0";
+        }
+        os << "}}";
     }
 
   private:
@@ -1146,7 +1183,8 @@ class PerfReport {
         std::string o = "{\"count\":" + std::to_string(s.count()) +
                         ",\"min\":" + std::to_string(s.min()) +
                         ",\"max\":" + std::to_string(s.max()) +
-                        ",\"mean\":" + std::to_string(s.mean());
+                        ",\"mean\":" + std::to_string(s.mean()) +
+                        ",\"variance\":" + std::to_string(s.variance());
         if (!s.histogram().empty()) {
             o += ",\"histogram\":{\"thresholds\":[";
             for (std::size_t i = 0; i < s.thresholds().size(); ++i)
@@ -1248,14 +1286,15 @@ std::size_t run_loopback(bool with_observers, std::size_t* stall_out) {
     std::size_t cycle = 0;
     const std::size_t cap = 100000;
     while ((!flow_a.done() || !flow_b.done()) && cycle < cap) {
+        now = cycle;  // cycle-start timestamp: callbacks (fired inside the ticks)
+                      // and sample() below all read the SAME now this iteration
         flow_a.pre_tick();
         flow_b.pre_tick();
         ch.tick();
         flow_a.post_tick();
         flow_b.post_tick();
-        ++cycle;
-        now = cycle;
         if (with_observers) { ni_a.sample(); ni_b.sample(); router_obs.sample(); }
+        ++cycle;
     }
     if (with_observers && (flow_a.done() && flow_b.done())) phase.begin_drain();
     if (stall_out) *stall_out = router_obs.credit_stall_cycles();
@@ -1337,7 +1376,12 @@ git commit -m "chore(perf): remove completed implementation plan"
   `RouterPerfObserver(now, phase, std::vector<ObservedRouter>, RouterPerfConfig)`,
   `IssueInfo{is_write,id,scenario_line,addr,size,len,burst}` are used identically
   across tasks.
-- Known soft spots flagged inline for the implementer (copy-construction boilerplate
-  in T3/T4 from sibling tests; the T7 credit==0 driving sequence): these are
-  construction details, not contract ambiguity -- the asserts pin the contract.
+- Codex plan-review (2026-06-17) resolved: T3 Memory/AxiMaster ctor signatures
+  corrected and verified against `memory.hpp` / `axi_master.hpp:103,520`; T4 uses
+  the concrete hermetic `NmuStandalone`; T6 adds the H4 drain-latency test
+  (Measurement-issued + Drain-completed -> recorded); T7 uses a deterministic
+  EAST-credit-exhaustion stall sequence; T9 sets the cycle timestamp at loop top
+  so callbacks and `sample()` share `now`. `Stats` gains `variance()`; JSON gains
+  `outstanding`/`variance`/`per_router` (spec §6 marks `phases` + per-port ratio
+  array deferred).
 ```

--- a/docs/superpowers/plans/2026-06-17-ni-router-perf-observer.md
+++ b/docs/superpowers/plans/2026-06-17-ni-router-perf-observer.md
@@ -1,0 +1,1343 @@
+# NI + Router Performance Observer Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add two testbench-only, non-intrusive performance observers (`NIPerfObserver`, `RouterPerfObserver`) plus shared `Stats` / `PhaseController` / `PerfReport` helpers, wired into `test_router_loopback`, emitting stdout summary + `NOC_PERF=1` JSON.
+
+**Architecture:** Observers are decoupled from concrete DUT types: `NIPerfObserver` consumes `AxiMaster` issue/completion callbacks + a `std::function<std::size_t()>` RoB-occupancy probe; `RouterPerfObserver` polls `const noc::Router&` introspection. A harness-owned `uint64_t cycle` is the single clock; both observers hold a `const uint64_t&`. Latency is gated by a per-transaction eligible flag; sampled metrics record only in the Measurement phase.
+
+**Tech Stack:** C++17, GoogleTest, header-only under `c_model/tests/common/` (namespace `ni::cmodel::testing`). Spec: `docs/superpowers/specs/2026-06-17-ni-router-perf-observer-design.md`.
+
+---
+
+## File structure
+
+New (all under `c_model/tests/common/`, header-only):
+- `perf_stats.hpp` -- `Stats` + `StatsConfig` (count/sum/min/max/mean + optional threshold-bin histogram).
+- `perf_common.hpp` -- `Phase`, `PhaseConfig`, `PhaseController`.
+- `ni_perf_observer.hpp` -- `NIPerfObserver` + `NIPerfConfig`.
+- `router_perf_observer.hpp` -- `RouterPerfObserver` + `RouterPerfConfig`.
+- `perf_report.hpp` -- `PerfReport` (stdout summary + JSON writer).
+
+New tests (`c_model/tests/common/`):
+- `test_perf_stats.cpp`, `test_perf_phase.cpp`, `test_ni_perf_observer.cpp`,
+  `test_router_perf_observer.cpp`, `test_perf_report.cpp`.
+
+Modified production headers (additive, const/append-only):
+- `c_model/include/axi/axi_master.hpp` -- multi-subscriber callbacks, `on_*_issued`, `IssueInfo`, wrapper forwarding.
+- `c_model/include/nmu/rob.hpp` -- `write_occupancy()` / `read_occupancy()`.
+- `c_model/include/noc/router.hpp` -- `front_route()`, `num_vc()`.
+
+Modified tests:
+- `c_model/tests/integration/test_router_loopback.cpp` -- observer wiring + A/B non-intrusive test.
+- `c_model/tests/common/CMakeLists.txt`, `c_model/tests/noc/CMakeLists.txt` -- register new tests (and front_route test).
+
+Reformat every touched `.hpp`/`.cpp` with `clang-format -i` before each commit.
+
+---
+
+## Task 1: Stats accumulator
+
+**Files:**
+- Create: `c_model/tests/common/perf_stats.hpp`
+- Test: `c_model/tests/common/test_perf_stats.cpp`
+- Modify: `c_model/tests/common/CMakeLists.txt`
+
+- [ ] **Step 1: Write the failing test**
+
+`c_model/tests/common/test_perf_stats.cpp`:
+
+```cpp
+#include "common/perf_stats.hpp"
+#include <gtest/gtest.h>
+
+using ni::cmodel::testing::Stats;
+using ni::cmodel::testing::StatsConfig;
+
+TEST(PerfStats, ScalarsOverKnownSequence) {
+    Stats s(StatsConfig{});  // no histogram
+    for (uint64_t v : {2u, 4u, 6u, 8u}) s.add(v);
+    EXPECT_EQ(s.count(), 4u);
+    EXPECT_EQ(s.sum(), 20u);
+    EXPECT_EQ(s.min(), 2u);
+    EXPECT_EQ(s.max(), 8u);
+    EXPECT_DOUBLE_EQ(s.mean(), 5.0);
+    EXPECT_TRUE(s.histogram().empty());
+}
+
+TEST(PerfStats, EmptyIsSafe) {
+    Stats s(StatsConfig{});
+    EXPECT_EQ(s.count(), 0u);
+    EXPECT_EQ(s.min(), 0u);
+    EXPECT_EQ(s.max(), 0u);
+    EXPECT_DOUBLE_EQ(s.mean(), 0.0);  // no div-by-zero
+}
+
+TEST(PerfStats, ThresholdBinsCountCorrectly) {
+    // thresholds {10,20}: bin0=[0,10) bin1=[10,20) bin2=[20,inf)
+    Stats s(StatsConfig{{10, 20}});
+    for (uint64_t v : {5u, 9u, 10u, 15u, 20u, 99u}) s.add(v);
+    ASSERT_EQ(s.histogram().size(), 3u);
+    EXPECT_EQ(s.histogram()[0], 2u);  // 5,9
+    EXPECT_EQ(s.histogram()[1], 2u);  // 10,15
+    EXPECT_EQ(s.histogram()[2], 2u);  // 20,99
+}
+```
+
+- [ ] **Step 2: Register the test and run it to verify it fails**
+
+Append to `c_model/tests/common/CMakeLists.txt`:
+
+```cmake
+add_cmodel_test(test_perf_stats)
+target_include_directories(test_perf_stats PRIVATE
+  ${CMAKE_CURRENT_SOURCE_DIR}/..)
+```
+
+Run: `make build-cmodel PYTHON3="py -3"` then `cd build/cmodel && ctest -R PerfStats`
+Expected: build FAIL (`perf_stats.hpp` not found).
+
+- [ ] **Step 3: Write minimal implementation**
+
+`c_model/tests/common/perf_stats.hpp`:
+
+```cpp
+#pragma once
+#include <cstddef>
+#include <cstdint>
+#include <limits>
+#include <utility>
+#include <vector>
+
+namespace ni::cmodel::testing {
+
+struct StatsConfig {
+    std::vector<uint64_t> bin_thresholds;  // ascending; empty = scalars only
+};
+
+// One metric's accumulator: count/sum/min/max + optional threshold-bin histogram.
+// Histogram is maintained only when bin_thresholds is non-empty (NOC_PERF gate).
+class Stats {
+  public:
+    explicit Stats(StatsConfig cfg) : thresholds_(std::move(cfg.bin_thresholds)) {
+        if (!thresholds_.empty()) bins_.assign(thresholds_.size() + 1, 0);
+    }
+    void add(uint64_t v) {
+        ++count_;
+        sum_ += v;
+        if (v < min_) min_ = v;
+        if (v > max_) max_ = v;
+        if (!thresholds_.empty()) ++bins_[bin_index_(v)];
+    }
+    uint64_t count() const { return count_; }
+    uint64_t sum() const { return sum_; }
+    uint64_t min() const { return count_ ? min_ : 0; }
+    uint64_t max() const { return count_ ? max_ : 0; }
+    double mean() const { return count_ ? static_cast<double>(sum_) / static_cast<double>(count_) : 0.0; }
+    const std::vector<uint64_t>& thresholds() const { return thresholds_; }
+    const std::vector<uint64_t>& histogram() const { return bins_; }
+
+  private:
+    std::size_t bin_index_(uint64_t v) const {
+        for (std::size_t i = 0; i < thresholds_.size(); ++i)
+            if (v < thresholds_[i]) return i;
+        return thresholds_.size();
+    }
+    std::vector<uint64_t> thresholds_;
+    std::vector<uint64_t> bins_;
+    uint64_t count_ = 0;
+    uint64_t sum_ = 0;
+    uint64_t min_ = std::numeric_limits<uint64_t>::max();
+    uint64_t max_ = 0;
+};
+
+}  // namespace ni::cmodel::testing
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `cd build/cmodel && ctest -R PerfStats --output-on-failure`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+clang-format -i c_model/tests/common/perf_stats.hpp c_model/tests/common/test_perf_stats.cpp
+git add c_model/tests/common/perf_stats.hpp c_model/tests/common/test_perf_stats.cpp c_model/tests/common/CMakeLists.txt
+git commit -m "test(perf): add Stats accumulator with threshold-bin histogram"
+```
+
+---
+
+## Task 2: PhaseController
+
+**Files:**
+- Create: `c_model/tests/common/perf_common.hpp`
+- Test: `c_model/tests/common/test_perf_phase.cpp`
+- Modify: `c_model/tests/common/CMakeLists.txt`
+
+- [ ] **Step 1: Write the failing test**
+
+`c_model/tests/common/test_perf_phase.cpp`:
+
+```cpp
+#include "common/perf_common.hpp"
+#include <gtest/gtest.h>
+
+using ni::cmodel::testing::Phase;
+using ni::cmodel::testing::PhaseConfig;
+using ni::cmodel::testing::PhaseController;
+
+TEST(PerfPhase, WarmupThenMeasurementThenDrain) {
+    uint64_t now = 0;
+    PhaseController p(now, PhaseConfig{/*warmup_cycles=*/3});
+    now = 0; EXPECT_EQ(p.phase(), Phase::Warmup);
+    now = 2; EXPECT_EQ(p.phase(), Phase::Warmup);
+    now = 3; EXPECT_EQ(p.phase(), Phase::Measurement);
+    now = 9; EXPECT_EQ(p.phase(), Phase::Measurement);
+    p.begin_drain();
+    EXPECT_EQ(p.phase(), Phase::Drain);
+}
+
+TEST(PerfPhase, ZeroWarmupStartsInMeasurement) {
+    uint64_t now = 0;
+    PhaseController p(now, PhaseConfig{});  // warmup_cycles=0
+    EXPECT_EQ(p.phase(), Phase::Measurement);
+}
+```
+
+- [ ] **Step 2: Register and run to verify it fails**
+
+Append to `c_model/tests/common/CMakeLists.txt`:
+
+```cmake
+add_cmodel_test(test_perf_phase)
+target_include_directories(test_perf_phase PRIVATE
+  ${CMAKE_CURRENT_SOURCE_DIR}/..)
+```
+
+Run: `make build-cmodel PYTHON3="py -3"`
+Expected: FAIL (`perf_common.hpp` not found).
+
+- [ ] **Step 3: Write minimal implementation**
+
+`c_model/tests/common/perf_common.hpp`:
+
+```cpp
+#pragma once
+#include <cstdint>
+
+namespace ni::cmodel::testing {
+
+enum class Phase { Warmup, Measurement, Drain };
+
+struct PhaseConfig {
+    uint64_t warmup_cycles = 0;
+};
+
+// Three-phase gating bound to the harness cycle counter by const reference.
+// Drain is one-way: begin_drain() is called once when all masters report done().
+class PhaseController {
+  public:
+    PhaseController(const uint64_t& now, PhaseConfig cfg) : now_(now), cfg_(cfg) {}
+    void begin_drain() { draining_ = true; }
+    Phase phase() const {
+        if (draining_) return Phase::Drain;
+        if (now_ < cfg_.warmup_cycles) return Phase::Warmup;
+        return Phase::Measurement;
+    }
+
+  private:
+    const uint64_t& now_;
+    PhaseConfig cfg_;
+    bool draining_ = false;
+};
+
+}  // namespace ni::cmodel::testing
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `cd build/cmodel && ctest -R PerfPhase --output-on-failure`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+clang-format -i c_model/tests/common/perf_common.hpp c_model/tests/common/test_perf_phase.cpp
+git add c_model/tests/common/perf_common.hpp c_model/tests/common/test_perf_phase.cpp c_model/tests/common/CMakeLists.txt
+git commit -m "test(perf): add PhaseController three-phase gating"
+```
+
+---
+
+## Task 3: AxiMaster multi-subscriber + issue callbacks (H1, issue hook)
+
+**Files:**
+- Modify: `c_model/include/axi/axi_master.hpp` (callback members 308-309 / 498-499; completion invokes 159 / 225; AW accept 435-436; AR accept 487-488; wrapper ~683-688)
+- Create: `c_model/tests/common/test_axi_master_callbacks.cpp`
+- Modify: `c_model/tests/common/CMakeLists.txt`
+
+- [ ] **Step 1: Write the failing test**
+
+This test stands up an `AxiMaster` over an `AxiSlave`+`Memory` with a one-write/one-read inline scenario, mirroring the construction already used in `c_model/tests/common/test_test_logger.cpp` (include the same headers and build the master from an inline YAML written to `::testing::TempDir()`). It registers TWO completion callbacks and ONE issue callback per direction and asserts: both completion callbacks fire, the issue callback fires exactly once before its completion, and the issue scenario_line equals the completion scenario_line.
+
+`c_model/tests/common/test_axi_master_callbacks.cpp`:
+
+```cpp
+#include "axi/axi_master.hpp"
+#include "axi/axi_slave.hpp"
+#include "axi/memory.hpp"
+#include "axi/scenario_parser.hpp"
+#include <gtest/gtest.h>
+#include <fstream>
+#include <string>
+#include <vector>
+
+namespace axi = ni::cmodel::axi;
+
+namespace {
+// Minimal single-write + single-read scenario, 1 beat, 1 byte.
+std::string write_inline_scenario() {
+    const std::string dir = std::string(::testing::TempDir()) + "/cb_scn";
+    std::ofstream(dir + ".yaml") <<
+        "schema_version: 1\n"
+        "metadata: {name: cb_scn, category: BAS}\n"
+        "config: {data_width_bytes: 32, addr_width_bits: 40, id_width_bits: 8,\n"
+        "         memory_base: 0, memory_size: 4096}\n"
+        "transactions:\n"
+        "  - {op: write, id: 0, addr: 0, size: 0, len: 0, burst: INCR}\n"
+        "  - {op: read,  id: 0, addr: 0, size: 0, len: 0, burst: INCR}\n";
+    std::ofstream(dir + ".data") << "AA\n";
+    return dir + ".yaml";
+}
+}  // namespace
+
+TEST(AxiMasterCallbacks, FanoutAndIssueBeforeCompletion) {
+    const std::string scn = write_inline_scenario();
+    axi::Memory mem(/*base=*/0, /*size=*/4096);
+    axi::AxiSlave slave(mem);
+    axi::AxiMaster master(scn, slave, /*max_out_w=*/1, /*max_out_r=*/1);
+
+    int wc1 = 0, wc2 = 0, w_issue = 0;
+    std::size_t issue_line = 999, complete_line = 888;
+    bool issue_seen_before_complete = false;
+
+    master.on_write_issued([&](const axi::IssueInfo& ii) {
+        ++w_issue;
+        issue_line = ii.scenario_line;
+    });
+    master.on_write_completed([&](const axi::WriteResult& wr) {
+        ++wc1;
+        complete_line = wr.scenario_line;
+        issue_seen_before_complete = (w_issue == 1);
+    });
+    master.on_write_completed([&](const axi::WriteResult&) { ++wc2; });
+
+    for (int cycle = 0; cycle < 200 && !master.done(); ++cycle) {
+        master.tick();
+        slave.tick();
+        mem.tick();
+    }
+    ASSERT_TRUE(master.done());
+    EXPECT_EQ(wc1, 1);   // first subscriber fired
+    EXPECT_EQ(wc2, 1);   // second subscriber fired (H1: not overwritten)
+    EXPECT_EQ(w_issue, 1);
+    EXPECT_TRUE(issue_seen_before_complete);
+    EXPECT_EQ(issue_line, complete_line);
+}
+```
+
+> Implementer note: the exact `AxiMaster` / `AxiSlave` / `Memory` ctor argument
+> order is whatever `test_test_logger.cpp` and `test_request_response_loopback.cpp`
+> already use; copy that construction verbatim if the signatures differ from the
+> sketch above. The assertions are the contract.
+
+- [ ] **Step 2: Register and run to verify it fails**
+
+Append to `c_model/tests/common/CMakeLists.txt`:
+
+```cmake
+add_cmodel_test(test_axi_master_callbacks)
+target_include_directories(test_axi_master_callbacks PRIVATE
+  ${CMAKE_CURRENT_SOURCE_DIR}/..)
+target_link_libraries(test_axi_master_callbacks PRIVATE yaml-cpp::yaml-cpp)
+```
+
+Run: `make build-cmodel PYTHON3="py -3"`
+Expected: FAIL -- `on_write_issued` / `IssueInfo` do not exist; second `on_write_completed` overwrites the first.
+
+- [ ] **Step 3: Add IssueInfo and change callbacks to multi-subscriber + issue hooks**
+
+In `c_model/include/axi/axi_master.hpp`, after the `ReadResult` struct (~line 88) add:
+
+```cpp
+struct IssueInfo {
+    bool is_write;
+    uint8_t id;
+    std::size_t scenario_line;
+    uint64_t addr;
+    uint8_t size;
+    uint8_t len;
+    Burst burst;
+};
+```
+
+Change the callback members (498-499) from single slots to vectors and add issue vectors:
+
+```cpp
+    std::vector<std::function<void(const WriteResult&)>> wcb_;
+    std::vector<std::function<void(const ReadResult&)>> rcb_;
+    std::vector<std::function<void(const IssueInfo&)>> iwcb_;
+    std::vector<std::function<void(const IssueInfo&)>> ircb_;
+```
+
+Change the registrars (308-309) to append and add the issue registrars:
+
+```cpp
+    void on_write_completed(std::function<void(const WriteResult&)> cb) { wcb_.push_back(std::move(cb)); }
+    void on_read_observed(std::function<void(const ReadResult&)> cb) { rcb_.push_back(std::move(cb)); }
+    void on_write_issued(std::function<void(const IssueInfo&)> cb) { iwcb_.push_back(std::move(cb)); }
+    void on_read_issued(std::function<void(const IssueInfo&)> cb) { ircb_.push_back(std::move(cb)); }
+```
+
+Change the completion invocation at line 159 (`wcb_(WriteResult{...})`) to fan out:
+
+```cpp
+                    for (auto& cb : wcb_)
+                        cb(WriteResult{op.src_txn.addr, op.src_txn.size, op.src_txn.len,
+                                       op.src_txn.burst, op.src_txn.lock, op.data,
+                                       op.strb_per_beat, op.worst_resp_, b->id,
+                                       op.src_txn.scenario_line});
+```
+
+Change the completion invocation at line 225 (`rcb_(ReadResult{...})`) to fan out:
+
+```cpp
+                    for (auto& cb : rcb_)
+                        cb(ReadResult{op.src_txn.addr, op.src_txn.size, op.src_txn.len,
+                                      op.src_txn.burst, op.read_accumulator, op.worst_resp_,
+                                      r->id, op.src_txn.scenario_line});
+```
+
+Fire the write issue callback on first-sub-burst AW accept. Replace lines 435-436:
+
+```cpp
+                const bool first_aw = (op.next_aw_sub_idx_ == 0);
+                if (!slave_.push_aw(aw)) return op.write_request_done();
+                ++op.next_aw_sub_idx_;
+                if (first_aw)
+                    for (auto& cb : iwcb_)
+                        cb(IssueInfo{true, id, op.src_txn.scenario_line, op.src_txn.addr,
+                                     op.src_txn.size, op.src_txn.len, op.src_txn.burst});
+```
+
+Fire the read issue callback on first-sub-burst AR accept. Replace lines 487-488:
+
+```cpp
+            const bool first_ar = (op.next_ar_sub_idx_ == 0);
+            if (!slave_.push_ar(ar)) return op.read_request_done();
+            ++op.next_ar_sub_idx_;
+            if (first_ar)
+                for (auto& cb : ircb_)
+                    cb(IssueInfo{false, id, op.src_txn.scenario_line, op.src_txn.addr,
+                                 op.src_txn.size, op.src_txn.len, op.src_txn.burst});
+```
+
+In the non-template `AxiMaster` wrapper (the forwarding block around 683-688), add forwarders mirroring the existing `on_write_completed` forwarder:
+
+```cpp
+    void on_write_issued(std::function<void(const IssueInfo&)> cb) {
+        inner_.on_write_issued(std::move(cb));
+    }
+    void on_read_issued(std::function<void(const IssueInfo&)> cb) {
+        inner_.on_read_issued(std::move(cb));
+    }
+```
+
+(`<functional>` and `<vector>` are already included via the existing callback members.)
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `cd build/cmodel && ctest -R AxiMasterCallbacks --output-on-failure`
+Expected: PASS. Then `ctest -R 'AxiMaster|Logger|Integration'` to confirm no regression from the fanout change.
+
+- [ ] **Step 5: Commit**
+
+```bash
+clang-format -i c_model/include/axi/axi_master.hpp c_model/tests/common/test_axi_master_callbacks.cpp
+git add c_model/include/axi/axi_master.hpp c_model/tests/common/test_axi_master_callbacks.cpp c_model/tests/common/CMakeLists.txt
+git commit -m "feat(axi): multi-subscriber completion callbacks + on_*_issued issue hooks"
+```
+
+---
+
+## Task 4: Rob occupancy getters (H? introspection)
+
+**Files:**
+- Modify: `c_model/include/nmu/rob.hpp` (public section, after `set_drain_observer` ~line 76; members `write_`/`read_` at 101-102)
+- Create: `c_model/tests/nmu/test_rob_occupancy.cpp`
+- Modify: `c_model/tests/nmu/CMakeLists.txt`
+
+- [ ] **Step 1: Write the failing test**
+
+`c_model/tests/nmu/test_rob_occupancy.cpp` (uses the hermetic `NmuStandalone`,
+which owns null NoC stubs and exposes `axi_slave_port()` / `tick()` / `rob()` --
+`nmu.hpp:255-272`):
+
+```cpp
+#include "axi/types.hpp"
+#include "nmu/nmu.hpp"
+#include <gtest/gtest.h>
+
+namespace nmu = ni::cmodel::nmu;
+namespace axi = ni::cmodel::axi;
+
+// Empty RoB reports zero occupancy; after one AW is accepted and forwarded
+// (push_aw queues in the port; tick() forwards it into the RoB) the write
+// occupancy is non-zero. With no B response arriving (null rsp stub) the
+// outstanding entry persists, so occupancy stays > 0.
+TEST(RobOccupancy, EmptyThenNonZeroAfterAw) {
+    nmu::NmuConfig cfg;  // defaults
+    nmu::NmuStandalone n(cfg);
+    EXPECT_EQ(n.rob().write_occupancy(), 0u);
+    EXPECT_EQ(n.rob().read_occupancy(), 0u);
+
+    axi::AwBeat aw{/*id=*/0, /*addr=*/0x1000, /*len=*/0, /*size=*/5,
+                   axi::Burst::INCR, /*cache=*/0xA, /*lock=*/0, /*prot=*/0x3,
+                   /*region=*/0xF, /*user=*/0x55, /*qos=*/0xC};
+    ASSERT_TRUE(n.axi_slave_port().push_aw(aw));
+    n.tick();  // port forwards AW into the RoB
+    EXPECT_GT(n.rob().write_occupancy(), 0u);
+}
+```
+
+> Implementer note: if `NmuConfig` requires any non-default field for a legal
+> single-NMU build, copy the minimal config from `test_request_response_loopback.cpp`.
+> The contract under test is: `write_occupancy()==0` before any AW, `>0` while one
+> AW is outstanding.
+
+- [ ] **Step 2: Register and run to verify it fails**
+
+Append to `c_model/tests/nmu/CMakeLists.txt`:
+
+```cmake
+add_cmodel_test(test_rob_occupancy)
+target_include_directories(test_rob_occupancy PRIVATE
+  ${CMAKE_CURRENT_SOURCE_DIR}/..)
+```
+
+Run: `make build-cmodel PYTHON3="py -3"`
+Expected: FAIL -- `write_occupancy()` does not exist.
+
+- [ ] **Step 3: Add the getters**
+
+In `c_model/include/nmu/rob.hpp`, in the public section (after `set_drain_observer`, before `private:`):
+
+```cpp
+    // Test introspection: current outstanding-entry count summed over all ids.
+    std::size_t write_occupancy() const {
+        std::size_t n = 0;
+        for (const auto& s : write_) n += s.outstanding.size();
+        return n;
+    }
+    std::size_t read_occupancy() const {
+        std::size_t n = 0;
+        for (const auto& s : read_) n += s.outstanding.size();
+        return n;
+    }
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `cd build/cmodel && ctest -R RobOccupancy --output-on-failure`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+clang-format -i c_model/include/nmu/rob.hpp c_model/tests/nmu/test_rob_occupancy.cpp
+git add c_model/include/nmu/rob.hpp c_model/tests/nmu/test_rob_occupancy.cpp c_model/tests/nmu/CMakeLists.txt
+git commit -m "feat(nmu): add Rob write_occupancy/read_occupancy introspection"
+```
+
+---
+
+## Task 5: Router front_route + num_vc (H3 fix)
+
+**Files:**
+- Modify: `c_model/include/noc/router.hpp` (introspection block ~120-125; uses private `input_fifo_` 145, `cfg_` 142, `route_compute` 60)
+- Test: `c_model/tests/noc/test_router_front_route.cpp`
+- Modify: `c_model/tests/noc/CMakeLists.txt`
+
+- [ ] **Step 1: Write the failing test**
+
+`c_model/tests/noc/test_router_front_route.cpp`:
+
+```cpp
+#include "noc/router.hpp"
+#include "flit.hpp"
+#include <gtest/gtest.h>
+
+namespace noc = ni::cmodel::noc;
+using ni::cmodel::Flit;
+
+static Flit make_flit(uint8_t dst_id, uint8_t vc) {
+    Flit f;
+    f.set_header_field("dst_id", dst_id);
+    f.set_header_field("vc_id", vc);
+    f.set_header_field("axi_ch", 0);
+    f.set_header_field("last", 1);
+    return f;
+}
+
+TEST(RouterFrontRoute, EmptyReturnsNullopt) {
+    noc::RouterConfig c;
+    c.x = 0; c.y = 0; c.mesh_x_dim = 2; c.mesh_y_dim = 1; c.num_vc = 1;
+    noc::Router r(c);
+    EXPECT_EQ(r.num_vc(), 1u);
+    EXPECT_FALSE(r.front_route(static_cast<std::size_t>(noc::RouterPort::LOCAL), 0).has_value());
+}
+
+TEST(RouterFrontRoute, FrontFlitRoutesEast) {
+    noc::RouterConfig c;
+    c.x = 0; c.y = 0; c.mesh_x_dim = 2; c.mesh_y_dim = 1; c.num_vc = 1;
+    noc::Router r(c);
+    r.input(static_cast<std::size_t>(noc::RouterPort::LOCAL)).push_flit(make_flit(/*dst=(1,0)*/ 0x01, 0));
+    r.tick();  // landing -> input FIFO
+    auto out = r.front_route(static_cast<std::size_t>(noc::RouterPort::LOCAL), 0);
+    ASSERT_TRUE(out.has_value());
+    EXPECT_EQ(*out, noc::RouterPort::EAST);
+}
+```
+
+- [ ] **Step 2: Register and run to verify it fails**
+
+Append to `c_model/tests/noc/CMakeLists.txt`:
+
+```cmake
+add_cmodel_test(test_router_front_route)
+target_include_directories(test_router_front_route PRIVATE
+  ${CMAKE_CURRENT_SOURCE_DIR}/..)
+```
+
+Run: `make build-cmodel PYTHON3="py -3"`
+Expected: FAIL -- `front_route` / `num_vc` do not exist.
+
+- [ ] **Step 3: Add the accessors**
+
+In `c_model/include/noc/router.hpp`, in the `// Test introspection` block (after `output_fifo_size`, ~line 125):
+
+```cpp
+    uint8_t num_vc() const { return cfg_.num_vc; }
+    // Front flit's routed output port for (in_port, vc), or nullopt if empty.
+    // Pure read; mirrors stage-2's route check without side effects.
+    std::optional<RouterPort> front_route(std::size_t in_port, uint8_t vc) const {
+        if (in_port >= ROUTER_PORT_COUNT || vc >= cfg_.num_vc) return std::nullopt;
+        const auto& q = input_fifo_[in_port][vc];
+        if (q.empty()) return std::nullopt;
+        const auto dst = static_cast<uint8_t>(q.front().get_header_field("dst_id"));
+        return route_compute(dst, cfg_);
+    }
+```
+
+(`<optional>` is already included at router.hpp:24.)
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `cd build/cmodel && ctest -R RouterFrontRoute --output-on-failure`
+Expected: PASS (2 tests). Then `ctest -R Router` to confirm no regression.
+
+- [ ] **Step 5: Commit**
+
+```bash
+clang-format -i c_model/include/noc/router.hpp c_model/tests/noc/test_router_front_route.cpp
+git add c_model/include/noc/router.hpp c_model/tests/noc/test_router_front_route.cpp c_model/tests/noc/CMakeLists.txt
+git commit -m "feat(noc): add Router front_route + num_vc introspection for perf probe"
+```
+
+---
+
+## Task 6: NIPerfObserver
+
+**Files:**
+- Create: `c_model/tests/common/ni_perf_observer.hpp`
+- Test: `c_model/tests/common/test_ni_perf_observer.cpp`
+- Modify: `c_model/tests/common/CMakeLists.txt`
+
+- [ ] **Step 1: Write the failing test**
+
+`c_model/tests/common/test_ni_perf_observer.cpp`:
+
+```cpp
+#include "common/ni_perf_observer.hpp"
+#include "common/perf_common.hpp"
+#include <gtest/gtest.h>
+
+using ni::cmodel::testing::NIPerfConfig;
+using ni::cmodel::testing::NIPerfObserver;
+using ni::cmodel::testing::PhaseConfig;
+using ni::cmodel::testing::PhaseController;
+
+TEST(NIPerfObserver, LatencyAndOutstandingPeak) {
+    uint64_t now = 0;
+    PhaseController phase(now, PhaseConfig{});  // measurement from cycle 0
+    std::size_t fake_rob = 0;
+    NIPerfObserver obs(now, phase, [&] { return fake_rob; }, NIPerfConfig{"NI"});
+
+    now = 5;  obs.on_issue(/*is_write=*/true, /*line=*/1);   // w outstanding=1
+    now = 6;  obs.on_issue(true, 2);                          // w outstanding=2 (peak)
+    now = 10; obs.on_complete(true, 1);                       // latency 10-5=5
+    now = 12; obs.on_complete(true, 2);                       // latency 12-6=6
+
+    EXPECT_EQ(obs.outstanding_peak(), 2u);
+    EXPECT_EQ(obs.write_latency().count(), 2u);
+    EXPECT_EQ(obs.write_latency().min(), 5u);
+    EXPECT_EQ(obs.write_latency().max(), 6u);
+    EXPECT_EQ(obs.stuck_count(), 0u);
+}
+
+TEST(NIPerfObserver, WarmupIssuedNotCountedButOutstandingBalances) {
+    uint64_t now = 0;
+    PhaseController phase(now, PhaseConfig{/*warmup_cycles=*/10});
+    NIPerfObserver obs(now, phase, [] { return std::size_t{0}; }, NIPerfConfig{"NI"});
+
+    now = 2; obs.on_issue(true, 1);     // issued in Warmup -> not eligible
+    now = 15; obs.on_complete(true, 1); // completes in Measurement
+    EXPECT_EQ(obs.write_latency().count(), 0u);  // not recorded
+    EXPECT_EQ(obs.stuck_count(), 0u);            // outstanding still balanced
+}
+
+TEST(NIPerfObserver, StuckTransactionSurfaced) {
+    uint64_t now = 0;
+    PhaseController phase(now, PhaseConfig{});
+    NIPerfObserver obs(now, phase, [] { return std::size_t{0}; }, NIPerfConfig{"NI"});
+    now = 1; obs.on_issue(false, 7);  // read issued, never completed
+    EXPECT_EQ(obs.stuck_count(), 1u);
+}
+```
+
+- [ ] **Step 2: Register and run to verify it fails**
+
+Append to `c_model/tests/common/CMakeLists.txt`:
+
+```cmake
+add_cmodel_test(test_ni_perf_observer)
+target_include_directories(test_ni_perf_observer PRIVATE
+  ${CMAKE_CURRENT_SOURCE_DIR}/..)
+```
+
+Run: `make build-cmodel PYTHON3="py -3"`
+Expected: FAIL (`ni_perf_observer.hpp` not found).
+
+- [ ] **Step 3: Write minimal implementation**
+
+`c_model/tests/common/ni_perf_observer.hpp`:
+
+```cpp
+#pragma once
+#include "common/perf_common.hpp"
+#include "common/perf_stats.hpp"
+#include <cstddef>
+#include <cstdint>
+#include <functional>
+#include <map>
+#include <string>
+#include <utility>
+
+namespace ni::cmodel::testing {
+
+struct NIPerfConfig {
+    std::string flow_label = "NI";
+    StatsConfig latency_stats{};    // thresholds when NOC_PERF=1, else empty
+    StatsConfig occupancy_stats{};
+};
+
+// NI-edge observer. Driven by AxiMaster issue/completion callbacks (template-free:
+// the harness forwards them) plus a per-cycle sample() polling a RoB-occupancy
+// probe. Latency keyed by scenario_line within ONE NMU (one instance per NMU).
+class NIPerfObserver {
+  public:
+    NIPerfObserver(const uint64_t& now, PhaseController& phase,
+                   std::function<std::size_t()> rob_occupancy_probe, NIPerfConfig cfg)
+        : now_(now), phase_(phase), rob_probe_(std::move(rob_occupancy_probe)),
+          cfg_(std::move(cfg)), wr_lat_(cfg_.latency_stats), rd_lat_(cfg_.latency_stats),
+          outstanding_(cfg_.occupancy_stats), rob_occ_(cfg_.occupancy_stats) {}
+
+    void on_issue(bool is_write, std::size_t line) {
+        auto& m = is_write ? wr_inflight_ : rd_inflight_;
+        m[line] = InFlight{now_, phase_.phase() == Phase::Measurement};
+        if (is_write) ++w_out_; else ++r_out_;
+        const std::size_t cur = w_out_ + r_out_;
+        if (cur > out_peak_) out_peak_ = cur;
+    }
+    void on_complete(bool is_write, std::size_t line) {
+        auto& m = is_write ? wr_inflight_ : rd_inflight_;
+        auto it = m.find(line);
+        if (it != m.end()) {
+            if (it->second.eligible)
+                (is_write ? wr_lat_ : rd_lat_).add(now_ - it->second.issue_cycle);
+            m.erase(it);
+        }
+        if (is_write) { if (w_out_) --w_out_; } else { if (r_out_) --r_out_; }
+    }
+    // Called once per cycle by the harness, AFTER component ticks.
+    void sample() {
+        if (phase_.phase() != Phase::Measurement) return;
+        outstanding_.add(w_out_ + r_out_);
+        rob_occ_.add(rob_probe_ ? rob_probe_() : 0);
+    }
+
+    const std::string& label() const { return cfg_.flow_label; }
+    const Stats& write_latency() const { return wr_lat_; }
+    const Stats& read_latency() const { return rd_lat_; }
+    const Stats& outstanding() const { return outstanding_; }
+    const Stats& rob_occupancy() const { return rob_occ_; }
+    std::size_t outstanding_peak() const { return out_peak_; }
+    std::size_t stuck_count() const { return wr_inflight_.size() + rd_inflight_.size(); }
+
+  private:
+    struct InFlight {
+        uint64_t issue_cycle;
+        bool eligible;
+    };
+    const uint64_t& now_;
+    PhaseController& phase_;
+    std::function<std::size_t()> rob_probe_;
+    NIPerfConfig cfg_;
+    Stats wr_lat_, rd_lat_, outstanding_, rob_occ_;
+    std::map<std::size_t, InFlight> wr_inflight_, rd_inflight_;
+    std::size_t w_out_ = 0, r_out_ = 0, out_peak_ = 0;
+};
+
+}  // namespace ni::cmodel::testing
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `cd build/cmodel && ctest -R NIPerfObserver --output-on-failure`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+clang-format -i c_model/tests/common/ni_perf_observer.hpp c_model/tests/common/test_ni_perf_observer.cpp
+git add c_model/tests/common/ni_perf_observer.hpp c_model/tests/common/test_ni_perf_observer.cpp c_model/tests/common/CMakeLists.txt
+git commit -m "test(perf): add NIPerfObserver (NI-edge latency/outstanding/rob occupancy)"
+```
+
+---
+
+## Task 7: RouterPerfObserver
+
+**Files:**
+- Create: `c_model/tests/common/router_perf_observer.hpp`
+- Test: `c_model/tests/common/test_router_perf_observer.cpp`
+- Modify: `c_model/tests/common/CMakeLists.txt`
+
+- [ ] **Step 1: Write the failing test**
+
+`c_model/tests/common/test_router_perf_observer.cpp`:
+
+```cpp
+#include "common/router_perf_observer.hpp"
+#include "common/perf_common.hpp"
+#include "noc/router.hpp"
+#include "flit.hpp"
+#include <gtest/gtest.h>
+
+namespace noc = ni::cmodel::noc;
+using ni::cmodel::Flit;
+using ni::cmodel::testing::PhaseConfig;
+using ni::cmodel::testing::PhaseController;
+using ni::cmodel::testing::RouterPerfConfig;
+using ni::cmodel::testing::RouterPerfObserver;
+
+static Flit make_flit(uint8_t dst_id) {
+    Flit f;
+    f.set_header_field("dst_id", dst_id);
+    f.set_header_field("vc_id", 0);
+    f.set_header_field("axi_ch", 0);
+    f.set_header_field("last", 1);
+    return f;
+}
+
+TEST(RouterPerfObserver, IdleRouterZeroStall) {
+    noc::RouterConfig c; c.x = 0; c.y = 0; c.mesh_x_dim = 2; c.mesh_y_dim = 1; c.num_vc = 1;
+    noc::Router r(c);
+    uint64_t now = 0;
+    PhaseController phase(now, PhaseConfig{});
+    RouterPerfObserver obs(now, phase, {{"req0", &r}}, RouterPerfConfig{});
+    obs.sample();
+    EXPECT_EQ(obs.credit_stall_cycles(), 0u);
+}
+
+TEST(RouterPerfObserver, FrontFlitNoCreditAccruesStall) {
+    noc::RouterConfig c; c.x = 0; c.y = 0; c.mesh_x_dim = 2; c.mesh_y_dim = 1;
+    c.num_vc = 1; c.vc_depth = 1; c.output_fifo_depth = 1;
+    noc::Router r(c);
+    // Drain EAST output credit to 0 by leaving no downstream: push enough flits
+    // routed EAST that the EAST output credit hits 0 while an input flit waits.
+    r.input(static_cast<std::size_t>(noc::RouterPort::LOCAL)).push_flit(make_flit(0x01));
+    r.tick();  // flit now in LOCAL input FIFO, routes EAST
+    // Force EAST credit to 0 via repeated grants with no credit return (no downstream set).
+    uint64_t now = 0;
+    PhaseController phase(now, PhaseConfig{});
+    RouterPerfObserver obs(now, phase, {{"req0", &r}}, RouterPerfConfig{});
+    // Tick until EAST credit is exhausted, then a waiting front flit + credit==0 = stall.
+    for (int i = 0; i < 4; ++i) {
+        r.input(static_cast<std::size_t>(noc::RouterPort::LOCAL)).push_flit(make_flit(0x01));
+        r.tick();
+        now = static_cast<uint64_t>(i);
+        obs.sample();
+    }
+    EXPECT_GT(obs.credit_stall_cycles(), 0u);
+}
+```
+
+> Implementer note: if forcing `credit==0` through repeated grants proves
+> fiddly, instead construct the stall condition directly -- the contract is only
+> "front flit routed to an output whose `credit(out,vc)==0` accrues a stall
+> cycle; an idle router accrues zero." Use whatever minimal `Router` driving
+> sequence reaches `credit(EAST,0)==0` with a LOCAL-input flit routed EAST.
+
+- [ ] **Step 2: Register and run to verify it fails**
+
+Append to `c_model/tests/common/CMakeLists.txt`:
+
+```cmake
+add_cmodel_test(test_router_perf_observer)
+target_include_directories(test_router_perf_observer PRIVATE
+  ${CMAKE_CURRENT_SOURCE_DIR}/..)
+```
+
+Run: `make build-cmodel PYTHON3="py -3"`
+Expected: FAIL (`router_perf_observer.hpp` not found).
+
+- [ ] **Step 3: Write minimal implementation**
+
+`c_model/tests/common/router_perf_observer.hpp`:
+
+```cpp
+#pragma once
+#include "common/perf_common.hpp"
+#include "common/perf_stats.hpp"
+#include "noc/router.hpp"
+#include <cstddef>
+#include <cstdint>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace ni::cmodel::testing {
+
+struct ObservedRouter {
+    std::string label;
+    const noc::Router* router;
+};
+
+struct RouterPerfConfig {
+    StatsConfig occupancy_stats{};  // thresholds when NOC_PERF=1, else empty
+};
+
+// Polls a set of Routers once per cycle (after their tick). Credit-stall =
+// a (in_port, vc) front flit routed to output p with credit(p,vc)==0.
+class RouterPerfObserver {
+  public:
+    RouterPerfObserver(const uint64_t& now, PhaseController& phase,
+                       std::vector<ObservedRouter> routers, RouterPerfConfig cfg)
+        : now_(now), phase_(phase), routers_(std::move(routers)), cfg_(std::move(cfg)) {
+        per_router_.reserve(routers_.size());
+        for (const auto& r : routers_) per_router_.push_back(PerRouter{cfg_.occupancy_stats});
+    }
+
+    void sample() {
+        (void)now_;
+        if (phase_.phase() != Phase::Measurement) return;
+        for (std::size_t ri = 0; ri < routers_.size(); ++ri) {
+            const noc::Router& r = *routers_[ri].router;
+            PerRouter& pr = per_router_[ri];
+            const uint8_t nvc = r.num_vc();
+            for (std::size_t in = 0; in < noc::ROUTER_PORT_COUNT; ++in) {
+                for (uint8_t vc = 0; vc < nvc; ++vc) {
+                    auto out = r.front_route(in, vc);
+                    if (out && r.credit(static_cast<std::size_t>(*out), vc) == 0) {
+                        ++credit_stall_cycles_;
+                        ++pr.stall;
+                    }
+                    pr.in_fifo.add(r.input_fifo_size(in, vc));
+                }
+            }
+            for (std::size_t p = 0; p < noc::ROUTER_PORT_COUNT; ++p) {
+                pr.out_fifo.add(r.output_fifo_size(p));
+                ++pr.out_cycles[p];
+                if (r.output_fifo_size(p) > 0) ++pr.out_nonempty[p];
+            }
+        }
+    }
+
+    std::size_t credit_stall_cycles() const { return credit_stall_cycles_; }
+    std::size_t router_count() const { return routers_.size(); }
+    const std::string& label(std::size_t i) const { return routers_[i].label; }
+    double out_nonempty_ratio(std::size_t i, std::size_t port) const {
+        const auto& pr = per_router_[i];
+        return pr.out_cycles[port] ? static_cast<double>(pr.out_nonempty[port]) /
+                                         static_cast<double>(pr.out_cycles[port])
+                                   : 0.0;
+    }
+    const Stats& in_fifo(std::size_t i) const { return per_router_[i].in_fifo; }
+    const Stats& out_fifo(std::size_t i) const { return per_router_[i].out_fifo; }
+    std::size_t stall(std::size_t i) const { return per_router_[i].stall; }
+
+  private:
+    struct PerRouter {
+        explicit PerRouter(StatsConfig c) : in_fifo(c), out_fifo(c) {}
+        Stats in_fifo;
+        Stats out_fifo;
+        std::size_t stall = 0;
+        std::size_t out_cycles[noc::ROUTER_PORT_COUNT] = {};
+        std::size_t out_nonempty[noc::ROUTER_PORT_COUNT] = {};
+    };
+    const uint64_t& now_;
+    PhaseController& phase_;
+    std::vector<ObservedRouter> routers_;
+    RouterPerfConfig cfg_;
+    std::vector<PerRouter> per_router_;
+    std::size_t credit_stall_cycles_ = 0;
+};
+
+}  // namespace ni::cmodel::testing
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `cd build/cmodel && ctest -R RouterPerfObserver --output-on-failure`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+clang-format -i c_model/tests/common/router_perf_observer.hpp c_model/tests/common/test_router_perf_observer.cpp
+git add c_model/tests/common/router_perf_observer.hpp c_model/tests/common/test_router_perf_observer.cpp c_model/tests/common/CMakeLists.txt
+git commit -m "test(perf): add RouterPerfObserver (credit-stall/fifo occupancy)"
+```
+
+---
+
+## Task 8: PerfReport (stdout summary + JSON)
+
+**Files:**
+- Create: `c_model/tests/common/perf_report.hpp`
+- Test: `c_model/tests/common/test_perf_report.cpp`
+- Modify: `c_model/tests/common/CMakeLists.txt`
+
+- [ ] **Step 1: Write the failing test**
+
+`c_model/tests/common/test_perf_report.cpp`:
+
+```cpp
+#include "common/ni_perf_observer.hpp"
+#include "common/perf_report.hpp"
+#include "common/perf_common.hpp"
+#include <gtest/gtest.h>
+#include <sstream>
+#include <string>
+
+using namespace ni::cmodel::testing;
+
+TEST(PerfReport, SummaryLineContainsLabels) {
+    uint64_t now = 0;
+    PhaseController phase(now, PhaseConfig{});
+    NIPerfObserver ni(now, phase, [] { return std::size_t{0}; }, NIPerfConfig{"flowA"});
+    now = 1; ni.on_issue(true, 1);
+    now = 4; ni.on_complete(true, 1);
+
+    std::ostringstream os;
+    PerfReport rep;
+    rep.add_ni(&ni);
+    rep.write_summary(os);
+    const std::string out = os.str();
+    EXPECT_NE(out.find("[perf:flowA]"), std::string::npos);
+    EXPECT_NE(out.find("wr_lat"), std::string::npos);
+}
+```
+
+- [ ] **Step 2: Register and run to verify it fails**
+
+Append to `c_model/tests/common/CMakeLists.txt`:
+
+```cmake
+add_cmodel_test(test_perf_report)
+target_include_directories(test_perf_report PRIVATE
+  ${CMAKE_CURRENT_SOURCE_DIR}/..)
+```
+
+Run: `make build-cmodel PYTHON3="py -3"`
+Expected: FAIL (`perf_report.hpp` not found).
+
+- [ ] **Step 3: Write minimal implementation**
+
+`c_model/tests/common/perf_report.hpp`:
+
+```cpp
+#pragma once
+#include "common/ni_perf_observer.hpp"
+#include "common/router_perf_observer.hpp"
+#include <cstdlib>
+#include <fstream>
+#include <iostream>
+#include <ostream>
+#include <string>
+#include <vector>
+
+namespace ni::cmodel::testing {
+
+// Aggregates NI + Router observers. Always prints a scalar stdout summary;
+// writes a JSON file only under NOC_PERF=1.
+class PerfReport {
+  public:
+    void add_ni(const NIPerfObserver* ni) { ni_.push_back(ni); }
+    void add_router(const RouterPerfObserver* r) { router_ = r; }
+
+    void write_summary(std::ostream& os) const {
+        for (const auto* ni : ni_) {
+            os << "[perf:" << ni->label() << "] "
+               << "wr_lat(min/mean/max)=" << ni->write_latency().min() << '/'
+               << ni->write_latency().mean() << '/' << ni->write_latency().max() << ' '
+               << "rd_lat(min/mean/max)=" << ni->read_latency().min() << '/'
+               << ni->read_latency().mean() << '/' << ni->read_latency().max() << ' '
+               << "outstanding_peak=" << ni->outstanding_peak() << ' '
+               << "rob_occ_peak=" << ni->rob_occupancy().max() << ' '
+               << "stuck=" << ni->stuck_count() << '\n';
+        }
+        if (router_) {
+            os << "[perf:ROUTER] credit_stall_cycles=" << router_->credit_stall_cycles() << '\n';
+        }
+    }
+
+    // Always summary; JSON only under NOC_PERF=1.
+    void emit(const std::string& run_label) const {
+        write_summary(std::cout);
+        const char* g = std::getenv("NOC_PERF");
+        if (!g || std::string(g) != "1") return;
+        const char* f = std::getenv("NOC_PERF_FILE");
+        const std::string path = f ? std::string(f) : ("perf_" + run_label + ".json");
+        std::ofstream js(path);
+        if (js) write_json(js);
+    }
+
+    void write_json(std::ostream& os) const {
+        os << "{\"ni\":[";
+        for (std::size_t i = 0; i < ni_.size(); ++i) {
+            const auto* ni = ni_[i];
+            if (i) os << ',';
+            os << "{\"label\":\"" << ni->label() << "\","
+               << "\"write_latency\":" << stat_json(ni->write_latency()) << ','
+               << "\"read_latency\":" << stat_json(ni->read_latency()) << ','
+               << "\"outstanding_peak\":" << ni->outstanding_peak() << ','
+               << "\"rob_occupancy\":" << stat_json(ni->rob_occupancy()) << '}';
+        }
+        os << "],\"router\":{\"credit_stall_cycles\":"
+           << (router_ ? router_->credit_stall_cycles() : 0) << "}}";
+    }
+
+  private:
+    static std::string stat_json(const Stats& s) {
+        std::string o = "{\"count\":" + std::to_string(s.count()) +
+                        ",\"min\":" + std::to_string(s.min()) +
+                        ",\"max\":" + std::to_string(s.max()) +
+                        ",\"mean\":" + std::to_string(s.mean());
+        if (!s.histogram().empty()) {
+            o += ",\"histogram\":{\"thresholds\":[";
+            for (std::size_t i = 0; i < s.thresholds().size(); ++i)
+                o += (i ? "," : "") + std::to_string(s.thresholds()[i]);
+            o += "],\"bins\":[";
+            for (std::size_t i = 0; i < s.histogram().size(); ++i)
+                o += (i ? "," : "") + std::to_string(s.histogram()[i]);
+            o += "]}";
+        }
+        return o + "}";
+    }
+    std::vector<const NIPerfObserver*> ni_;
+    const RouterPerfObserver* router_ = nullptr;
+};
+
+}  // namespace ni::cmodel::testing
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `cd build/cmodel && ctest -R PerfReport --output-on-failure`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+clang-format -i c_model/tests/common/perf_report.hpp c_model/tests/common/test_perf_report.cpp
+git add c_model/tests/common/perf_report.hpp c_model/tests/common/test_perf_report.cpp c_model/tests/common/CMakeLists.txt
+git commit -m "test(perf): add PerfReport stdout summary + NOC_PERF JSON"
+```
+
+---
+
+## Task 9: Wire observers into test_router_loopback + non-intrusive A/B test
+
+**Files:**
+- Modify: `c_model/tests/integration/test_router_loopback.cpp` (Flow class ~95-233; driving loop 299-313)
+
+The `Flow` class owns `master_`, `nmu_`, scoreboard. Add accessors so the test
+can attach an `NIPerfObserver`, and run the existing parametrised body once more
+with observers attached, asserting the loop's `cycle` and scoreboard mismatches
+are identical to a clean run.
+
+- [ ] **Step 1: Add Flow accessors**
+
+In the `Flow` class public section (near `done()` / `mismatches()` ~line 233):
+
+```cpp
+    auto& master() { return master_; }
+    const ni::cmodel::nmu::Rob& rob() const { return nmu_.rob(); }
+    uint8_t node_index() const { return static_cast<uint8_t>(master_node_); }
+```
+
+(If `master_node_` is not stored, add `std::size_t master_node_;` set in the ctor.)
+
+- [ ] **Step 2: Write the failing non-intrusive test**
+
+Add to `c_model/tests/integration/test_router_loopback.cpp` (after the existing
+`INSTANTIATE_TEST_SUITE_P`), a standalone TEST that runs the num_vc=1 fabric
+twice -- once plain, once with observers -- and asserts identical cycle count
+and mismatches:
+
+```cpp
+#include "common/ni_perf_observer.hpp"
+#include "common/router_perf_observer.hpp"
+#include "common/perf_common.hpp"
+
+namespace {
+
+std::size_t run_loopback(bool with_observers, std::size_t* stall_out) {
+    using namespace ni::cmodel::testing;
+    const std::size_t num_vc = 1;
+    TwoNodeFabric ch;
+    const std::string base = scenario_path("AX4-BAS-003_single_write_read_aligned");
+    const std::string tmp = std::string(::testing::TempDir());
+    Flow flow_a(ch, 1, 0, base, num_vc, tmp + "/ab_a.read.txt", 0x00);
+    const std::string yaml_b = shifted_scenario_path(base, 0x100000000, 9001);
+    Flow flow_b(ch, 0, 1, yaml_b, num_vc, tmp + "/ab_b.read.txt", 0x01);
+
+    uint64_t now = 0;
+    PhaseController phase(now, PhaseConfig{});
+    NIPerfObserver ni_a(now, phase, [&] { return flow_a.rob().write_occupancy() + flow_a.rob().read_occupancy(); }, NIPerfConfig{"A"});
+    NIPerfObserver ni_b(now, phase, [&] { return flow_b.rob().write_occupancy() + flow_b.rob().read_occupancy(); }, NIPerfConfig{"B"});
+    RouterPerfObserver router_obs(now, phase,
+        {{"req0", &ch.req_router(0)}, {"req1", &ch.req_router(1)},
+         {"rsp0", &ch.rsp_router(0)}, {"rsp1", &ch.rsp_router(1)}}, RouterPerfConfig{});
+
+    if (with_observers) {
+        flow_a.master().on_write_issued([&](const ni::cmodel::axi::IssueInfo& i){ ni_a.on_issue(true, i.scenario_line); });
+        flow_a.master().on_read_issued([&](const ni::cmodel::axi::IssueInfo& i){ ni_a.on_issue(false, i.scenario_line); });
+        flow_a.master().on_write_completed([&](const ni::cmodel::axi::WriteResult& w){ ni_a.on_complete(true, w.scenario_line); });
+        flow_a.master().on_read_observed([&](const ni::cmodel::axi::ReadResult& r){ ni_a.on_complete(false, r.scenario_line); });
+        flow_b.master().on_write_issued([&](const ni::cmodel::axi::IssueInfo& i){ ni_b.on_issue(true, i.scenario_line); });
+        flow_b.master().on_read_issued([&](const ni::cmodel::axi::IssueInfo& i){ ni_b.on_issue(false, i.scenario_line); });
+        flow_b.master().on_write_completed([&](const ni::cmodel::axi::WriteResult& w){ ni_b.on_complete(true, w.scenario_line); });
+        flow_b.master().on_read_observed([&](const ni::cmodel::axi::ReadResult& r){ ni_b.on_complete(false, r.scenario_line); });
+    }
+
+    std::size_t cycle = 0;
+    const std::size_t cap = 100000;
+    while ((!flow_a.done() || !flow_b.done()) && cycle < cap) {
+        flow_a.pre_tick();
+        flow_b.pre_tick();
+        ch.tick();
+        flow_a.post_tick();
+        flow_b.post_tick();
+        ++cycle;
+        now = cycle;
+        if (with_observers) { ni_a.sample(); ni_b.sample(); router_obs.sample(); }
+    }
+    if (with_observers && (flow_a.done() && flow_b.done())) phase.begin_drain();
+    if (stall_out) *stall_out = router_obs.credit_stall_cycles();
+    EXPECT_EQ(flow_a.mismatches(), 0u);
+    EXPECT_EQ(flow_b.mismatches(), 0u);
+    return cycle;
+}
+
+}  // namespace
+
+TEST(RouterLoopbackPerf, ObserversAreNonIntrusive) {
+    std::size_t stall = 0;
+    const std::size_t plain = run_loopback(/*with_observers=*/false, nullptr);
+    const std::size_t obs = run_loopback(/*with_observers=*/true, &stall);
+    EXPECT_EQ(plain, obs) << "attaching observers changed cycle-to-completion";
+}
+```
+
+- [ ] **Step 3: Run to verify it fails, then build**
+
+Run: `make build-cmodel PYTHON3="py -3"`
+If `test_router_loopback` does not yet include the common headers, add to its
+`target_include_directories` in `c_model/tests/integration/CMakeLists.txt`:
+`${CMAKE_CURRENT_SOURCE_DIR}/..` (so `common/...` resolves).
+Expected first run: build error until Flow accessors (Step 1) are present.
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `cd build/cmodel && ctest -R RouterLoopbackPerf --output-on-failure`
+Expected: PASS -- identical cycle count with and without observers.
+
+- [ ] **Step 5: Commit**
+
+```bash
+clang-format -i c_model/tests/integration/test_router_loopback.cpp
+git add c_model/tests/integration/test_router_loopback.cpp c_model/tests/integration/CMakeLists.txt
+git commit -m "test(perf): wire NI+Router observers into router loopback, assert non-intrusive"
+```
+
+---
+
+## Task 10: Full gate + plan cleanup
+
+- [ ] **Step 1: Run the full pre-submit gate**
+
+Run: `make check PYTHON3="py -3"`
+Expected: lint_scenarios + lint_docs + build + full ctest all green, including the
+new `PerfStats`, `PerfPhase`, `AxiMasterCallbacks`, `RobOccupancy`,
+`RouterFrontRoute`, `NIPerfObserver`, `RouterPerfObserver`, `PerfReport`,
+`RouterLoopbackPerf` tests.
+
+- [ ] **Step 2: Optional manual JSON smoke**
+
+Run: `cd build/cmodel && NOC_PERF=1 ctest -R RouterLoopbackPerf` and confirm a
+`perf_*.json` is produced and parses (the integration test does not assert JSON;
+this is a manual confirmation only).
+
+- [ ] **Step 3: Remove this plan and the spec's Draft status**
+
+Once all tasks are merged, delete `docs/superpowers/plans/2026-06-17-ni-router-perf-observer.md`
+and update the spec header `Status:` to `Implemented`.
+
+```bash
+git rm docs/superpowers/plans/2026-06-17-ni-router-perf-observer.md
+git commit -m "chore(perf): remove completed implementation plan"
+```
+
+---
+
+## Self-review notes
+
+- Spec coverage: Stats (T1), PhaseController (T2), AxiMaster issue+fanout / H1 (T3),
+  Rob occupancy (T4), Router front_route / H3 (T5), NIPerfObserver + per-NMU key /
+  H2 + eligible flag / H4 (T6), RouterPerfObserver (T7), PerfReport stdout+JSON (T8),
+  loopback wiring + non-intrusive A/B (T9). QoS, CSR, layer-1 BFM, deep congestion,
+  credit-RTT are spec non-goals -- no tasks, intentional.
+- Type consistency: `Stats(StatsConfig)`, `PhaseController(const uint64_t&, PhaseConfig)`,
+  `NIPerfObserver(now, phase, std::function<std::size_t()>, NIPerfConfig)`,
+  `RouterPerfObserver(now, phase, std::vector<ObservedRouter>, RouterPerfConfig)`,
+  `IssueInfo{is_write,id,scenario_line,addr,size,len,burst}` are used identically
+  across tasks.
+- Known soft spots flagged inline for the implementer (copy-construction boilerplate
+  in T3/T4 from sibling tests; the T7 credit==0 driving sequence): these are
+  construction details, not contract ambiguity -- the asserts pin the contract.
+```

--- a/docs/superpowers/specs/2026-06-17-ni-router-perf-observer-design.md
+++ b/docs/superpowers/specs/2026-06-17-ni-router-perf-observer-design.md
@@ -226,21 +226,31 @@ finite loopback scenarios, so they stay behind the guard).
   histogram (first bin whose cumulative count crosses 99%) and so appears only
   in the JSON, not the always-on summary. JSON schema:
 
+Each `Stats` object serializes `{count,min,max,mean,variance}` plus
+`histogram:{thresholds,bins}` when histograms are enabled. v1 JSON (delivered
+shape):
+
 ```json
 {
-  "ni": {
-    "write_latency": {"count":N,"min":..,"mean":..,"max":..,"histogram":{"thresholds":[..],"bins":[..]}},
-    "read_latency":  {...},
-    "outstanding":   {"peak":..,"histogram":{...}},
-    "rob_occupancy": {"peak":..,"histogram":{...}}
-  },
+  "ni": [
+    {"label":"flowA",
+     "write_latency":  {"count":N,"min":..,"max":..,"mean":..,"variance":..,"histogram":{...}},
+     "read_latency":   {...},
+     "outstanding_peak": P,
+     "outstanding":    {...Stats...},
+     "rob_occupancy":  {...Stats...}}
+  ],
   "router": {
     "credit_stall_cycles": M,
-    "per_port": [{"port":0,"out_nonempty_ratio":0.0,"in_fifo":{...},"out_fifo":{...},"credit":{...}}, ...]
-  },
-  "phases": {"warmup_cycles":..,"measurement_cycles":..,"drain_cycles":..}
+    "per_router": [{"label":"req0","stall":..,"in_fifo":{...Stats...},"out_fifo":{...Stats...}}, ...]
+  }
 }
 ```
+
+Deferred to a JSON follow-on (kept out of v1 to bound untested telemetry code):
+the `phases` block (`warmup/measurement/drain` cycle counts) and a per-output-port
+`out_nonempty_ratio` array. The per-port ratios are still printed in the always-on
+stdout summary.
 
 With multiple NMUs the `ni` object is an array keyed by flow label (one entry
 per `NIPerfObserver`). JSON path: `NOC_PERF_FILE` env override, else

--- a/docs/superpowers/specs/2026-06-17-ni-router-perf-observer-design.md
+++ b/docs/superpowers/specs/2026-06-17-ni-router-perf-observer-design.md
@@ -1,0 +1,332 @@
+# NI + Router Performance Observer Design
+
+Date: 2026-06-17
+Status: Draft (pending Codex review + user review)
+Scope: two testbench-only, non-intrusive performance observers for the c_model
+NoC -- `NIPerfObserver` (NI-edge latency / outstanding / RoB occupancy) and
+`RouterPerfObserver` (credit-stall / FIFO occupancy / output-port congestion) --
+plus shared `Stats` / `PhaseController` helpers and a `PerfReport` writer.
+Telemetry only; no CSR model.
+
+## 1. Motivation
+
+The c_model now drives a real wormhole VC router fabric
+(`noc/router.hpp`, `RouterChannel`) on the `tb_top` path, so latency,
+congestion, occupancy, and credit-stall are physically meaningful (router-cycle
+level), not stub artifacts. We want architectural performance telemetry at two
+layers without perturbing DUT timing.
+
+Survey basis (not a committed doc): the Arteris/Qualcomm latency-probe patent
+EP2724234A2 histogram model, Goossens/Ciordas event-based NoC monitoring, and
+BookSim2 measurement methodology. This design ports BookSim2's three-phase
+measurement, tail-retirement latency sampling, and `Stats` histogram form.
+
+## 2. Tap layers
+
+```
+AxiMaster --[1 BFM end-to-end]--> NMU --[2 NI edge]--> Router fabric --> NSU --[2]--> AxiSlave
+                                       (NIPerfObserver)   (RouterPerfObserver, layer 3)
+```
+
+- Layer 2 (NI edge): NMU master-facing `axi_slave_port` AW/AR accept + B/R emit;
+  RoB introspection. Measured by `NIPerfObserver`.
+- Layer 3 (fabric): `Router` credit / FIFO state. Measured by
+  `RouterPerfObserver`.
+- Layer 1 (BFM end-to-end, master-side queueing included): out of scope this
+  round.
+
+In the loopback testbenches the `AxiMaster` is bound directly to the NMU
+`axi_slave_port`, so an AW accepted by the NMU is the NI-edge ingress and a B
+emitted by the NMU is the NI-edge egress. `NIPerfObserver` latency is therefore
+NI-edge latency, not BFM end-to-end latency.
+
+## 3. Components
+
+| Component | Purpose | Depends on |
+|---|---|---|
+| `Stats` | one metric's accumulator: count/sum/sumsq/min/max + optional threshold-bin histogram | none |
+| `PhaseController` | warmup / measurement / drain gating | cycle ref |
+| `NIPerfObserver` (per NMU) | NI-edge latency, NI outstanding, RoB occupancy, per-ID | cycle ref, `PhaseController`, `AxiMaster` callbacks, `Nmu` introspection |
+| `RouterPerfObserver` | credit-stall, FIFO occupancy, output-port occupancy | cycle ref, `PhaseController`, `Router` introspection |
+| `PerfReport` | aggregate all observers -> stdout summary + env-gated JSON | the observers |
+
+All live in `c_model/tests/common/` under `ni::cmodel::testing` (same home and
+namespace as `AxiMasterObserver`). None are linked into production builds.
+`PhaseController` and the small free helpers share one `perf_common.hpp` (not a
+separate class per concept -- v1 keeps the surface small).
+
+### 3.1 Cycle source
+
+No separate clock class (revised after review: a standalone `CycleClock` is
+over-split for v1 and was not wired to the existing harness, which already owns
+an `int cycle` loop counter). The harness owns a single `uint64_t cycle`,
+incremented once per simulated cycle at loop top (cycle start). Every observer
+holds a `const uint64_t& now_` bound to it; callbacks and `sample()` read
+`now_`. The convention is fixed: `now_` is the cycle-start value for the whole
+iteration, so an issue callback and a same-cycle sample see the same number. A
++/-1 skew vs the component tick is acceptable for histogram-grade telemetry.
+
+### 3.2 Stats (BookSim2 port)
+
+```cpp
+struct StatsConfig {
+    std::vector<uint64_t> bin_thresholds;  // ascending; bin i = [t[i-1], t[i])
+};                                          // last bin = [t.back(), +inf)
+
+class Stats {
+  public:
+    explicit Stats(StatsConfig cfg);
+    void add(uint64_t value);   // updates count/sum/sumsq/min/max + histogram bin
+    uint64_t count() const; double mean() const; double variance() const;
+    uint64_t min() const; uint64_t max() const;
+    const std::vector<uint64_t>& histogram() const;
+};
+```
+
+Thresholds are configurable (parameterized design; no hardcoded bin edges).
+Default latency thresholds and occupancy thresholds are supplied by the
+observer configs, not baked into `Stats`.
+
+### 3.3 PhaseController
+
+```cpp
+enum class Phase { Warmup, Measurement, Drain };
+
+struct PhaseConfig { uint64_t warmup_cycles = 0; };
+
+class PhaseController {
+  public:
+    PhaseController(const uint64_t& now, PhaseConfig cfg);
+    void begin_drain();          // harness calls when all masters report done()
+    Phase phase() const;         // Warmup if now<warmup_cycles; Drain if begin_drain seen; else Measurement
+};
+```
+
+Recording rules (BookSim2 semantics), made explicit after review (H4):
+
+- Outstanding counters update for *every* transaction (+1 on issue, -1 on
+  completion) regardless of phase, so the count can never go negative when a
+  Warmup-issued transaction completes in Drain.
+- Latency samples are gated by a per-transaction `eligible_for_latency` flag,
+  set at issue iff `phase()==Measurement`. Completion records a latency sample
+  only when the flag is set; its completion cycle may fall in Drain. Each
+  in-flight transaction record carries `{issue_cycle, eligible_for_latency}`.
+- Per-cycle sampled metrics (occupancy, credit-stall, output-port occupancy):
+  recorded only while `phase()==Measurement`.
+
+For finite AXI scenarios the default `warmup_cycles=0` makes Measurement begin
+at cycle 0; Drain begins when injection completes. The three-phase machinery is
+present and exercised, and degrades to "measure the whole run" for finite
+workloads.
+
+## 4. Metrics and derivation
+
+### 4.1 NIPerfObserver
+
+One `NIPerfObserver` instance per NMU (per flow). This is the fix for the H2
+key-collision finding: `scenario_line` is unique only *within* one master's
+scenario, and the two loopback masters share a shifted copy of the same
+scenario, so a global key would collide. Scoping one observer to one NMU's
+issue/complete stream makes `scenario_line` a sufficient correlation key with no
+global tx-id.
+
+| Metric | Derivation | Recording |
+|---|---|---|
+| NI-edge write latency | `now(on B emit) - issue_cycle(on AW accept)`, keyed by scenario_line | `Stats`, per direction |
+| NI-edge read latency | `now(on R last beat) - issue_cycle(on AR accept)` | `Stats` |
+| NI outstanding (write/read) | running count, +1 on issue / -1 on completion, *all* transactions | peak + per-cycle `Stats` occupancy |
+| Per-ID outstanding | per-id running count from the issue/complete stream | peak per id |
+| RoB occupancy | poll `Nmu::rob().occupancy()` each cycle | `Stats` occupancy |
+
+Correlation key is `scenario_line` within this observer's NMU. The observer
+holds `map<scenario_line, {issue_cycle, eligible_for_latency}>`; completion looks
+it up, computes latency (if eligible), erases. A transaction splits into one or
+more sub-bursts (`axi_master.hpp`); the issue timestamp is the accept of the
+*first* sub-burst's AW/AR, the completion is the final B / R-last of the logical
+transaction.
+
+Event sources: `AxiMaster::on_write_issued` / `on_read_issued` (new, see Sec. 5)
+fire at AW/AR accept; `on_write_completed` / `on_read_observed` (existing) fire
+at B / R-last. RoB occupancy is polled, so `NIPerfObserver::sample()` is called
+once per cycle by the harness, after the component ticks.
+
+### 4.2 RouterPerfObserver
+
+Polls each observed `Router` once per cycle via `sample()`, called *after* the
+router tick so the input FIFOs (not the stage-1 `landing_` register) hold the
+flits being arbitrated this cycle:
+
+| Metric | Derivation (per output port `p`, vc `v`) | Recording |
+|---|---|---|
+| Credit-stall cycles | cycles where an input FIFO front flit is routed to `p`/`v` AND `credit(p,v)==0` | counter + per-port `Stats` |
+| Per-VC credit balance | `credit(p,v)` snapshot | `Stats` occupancy |
+| Input FIFO occupancy | `input_fifo_size(port,vc)` | `Stats` occupancy |
+| Output FIFO occupancy | `output_fifo_size(port)` | `Stats` occupancy |
+| Output-port non-empty ratio | cycles `output_fifo_size(p)>0` / measurement cycles | ratio (occupancy proxy, not throughput) |
+
+Credit-stall needs the front flit's routed output port, which is *not* derivable
+from the existing public accessors (`input_fifo_size` returns a count only;
+`input_fifo_` / `landing_` are private). This was the H3 finding -- the prior
+"Router needs no change" claim was wrong. Resolution: add one const
+test-introspection accessor to `Router` (see Sec. 5) that reports, per
+`(in_port, vc)`, the front flit's `route_compute` output port (or
+`std::nullopt` when empty), mirroring stage-2's eligibility check without side
+effects.
+
+Deeper contention (wormhole-lock loss, arbitration-loss attribution) is deferred
+-- it needs event hooks inside `Router::tick`, a larger production change.
+
+## 5. Production changes
+
+Minimal, in-pattern, additive only:
+
+1. **Multi-subscriber callbacks (H1 fix).** The existing `on_write_completed` /
+   `on_read_observed` are single `std::function` slots (`axi_master.hpp:308-309,
+   498-499`); the loopback already binds the scoreboard there, so a second
+   `on_*` call would silently overwrite it. Convert the four callbacks to
+   *append* semantics (each holds a `std::vector<std::function<...>>` and fans
+   out in registration order). Audit confirms current callers register exactly
+   once, so append is behaviour-preserving. The observer then coexists with the
+   scoreboard without the harness having to hand-compose a combined lambda.
+
+2. **`AxiMaster::on_write_issued(cb)` / `on_read_issued(cb)`** -- symmetric with
+   the completion callbacks. Each fires immediately after the downstream port
+   accepts the AW / AR (i.e. right after `slave_.push_aw(...)` / `push_ar(...)`
+   returns true, `axi_master.hpp:435-436`), passing
+   `{id, scenario_line, addr, size, len, burst}`. For a multi-sub-burst
+   transaction the callback fires once, on the first sub-burst's AW/AR accept.
+
+3. **`Rob::occupancy() const`** -- a const introspection accessor following the
+   existing "Test introspection (optional getters; add only as test code needs)"
+   note in `nmu.hpp`. `Nmu::rob()` already returns `const Rob&`; `Rob` currently
+   exposes no depth getter (`rob.hpp`), so this is new (~3 lines).
+
+4. **`Router` front-flit route accessor (H3 fix)** -- a const method, e.g.
+   `std::optional<RouterPort> front_route(std::size_t in_port, uint8_t vc) const`,
+   that returns `route_compute(front.dst_id)` for a non-empty `(in_port, vc)`
+   input FIFO else `std::nullopt`. Pure read of existing private state, no side
+   effects; joins the existing `credit()` / `input_fifo_size()` /
+   `output_fifo_size()` introspection set.
+
+All four are additive and const/append-only; no existing behaviour changes.
+
+## 6. Output
+
+Two-tier, gated like the existing `NOC_LOG`. The cheap scalars are always
+collected; the full threshold-bin histograms are collected and emitted only
+under `NOC_PERF=1` (review YAGNI note: histograms are over-weight for the small
+finite loopback scenarios, so they stay behind the guard).
+
+- Always: one-line stdout summary per observer at end of run, using only
+  scalars (count / min / mean / max / peak -- no histogram), e.g.
+  `[perf:NI] wr_lat(min/mean/max)=... rd_lat=... outstanding_peak=... rob_occ_peak=...`
+  `[perf:ROUTER] credit_stall_cycles=... out_nonempty_ratio(p0..p4)=... in_fifo_peak=...`
+- `NOC_PERF=1`: `Stats` additionally maintains the threshold-bin histogram and a
+  structured JSON file is dumped (one object per run). p99 is read off the
+  histogram (first bin whose cumulative count crosses 99%) and so appears only
+  in the JSON, not the always-on summary. JSON schema:
+
+```json
+{
+  "ni": {
+    "write_latency": {"count":N,"min":..,"mean":..,"max":..,"histogram":{"thresholds":[..],"bins":[..]}},
+    "read_latency":  {...},
+    "outstanding":   {"peak":..,"histogram":{...}},
+    "rob_occupancy": {"peak":..,"histogram":{...}}
+  },
+  "router": {
+    "credit_stall_cycles": M,
+    "per_port": [{"port":0,"out_nonempty_ratio":0.0,"in_fifo":{...},"out_fifo":{...},"credit":{...}}, ...]
+  },
+  "phases": {"warmup_cycles":..,"measurement_cycles":..,"drain_cycles":..}
+}
+```
+
+With multiple NMUs the `ni` object is an array keyed by flow label (one entry
+per `NIPerfObserver`). JSON path: `NOC_PERF_FILE` env override, else
+`<cwd>/perf_<run-label>.json`, where `run-label` is supplied by the harness
+(for the gtest integration: the test/param name plus scenario id); the
+observers do not invent it.
+
+## 7. Harness integration
+
+The harness owns the `uint64_t cycle` the observers bind to (Sec. 3.1). Per
+simulated cycle the loop does, in order:
+
+```cpp
+++cycle;                       // cycle-start value the observers read this iteration
+// ... existing pre_tick / component ticks / post_tick (incl. router tick) ...
+for (auto& ni : ni_obs) ni.sample();   // after ticks: RoB occupancy + per-cycle outstanding
+for (auto& r  : router_obs) r.sample(); // after router tick: input-FIFO state (not landing_)
+```
+
+The issue / completion callbacks fire inside the component ticks and read the
+same `cycle`. When every master reports `done()`, the harness calls
+`phase.begin_drain()` once. At loop exit `PerfReport{ni_obs, router_obs}.emit()`
+prints the summary and (if `NOC_PERF=1`) writes JSON.
+
+Instance count for the `test_router_loopback` two-node bidirectional fabric:
+**two** `NIPerfObserver` (one per NMU / flow, labelled by flow) and **one**
+`RouterPerfObserver` observing **all four** `TwoNodeFabric` routers (REQ/RSP x
+node0/node1), each router's metrics tagged `{network: req|rsp, node: 0|1}`.
+
+Wiring is additive: existing tests that do not construct the observers are
+unaffected. First integration target is `test_router_loopback.cpp` (real
+fabric, both flows).
+
+## 8. Testing
+
+Per the project rule (one happy-path + one error/edge test per new file):
+
+- `Stats`: known value sequence -> exact count/mean/min/max/bin counts; empty
+  `Stats` (count==0) returns sane mean (no div-by-zero).
+- `PhaseController`: warmup boundary excludes pre-warmup samples; `begin_drain`
+  flips phase; a latency sample issued in Measurement but completing in Drain is
+  recorded.
+- `NIPerfObserver`: injected issue/complete pairs (test-injection ctor, mirroring
+  `AxiMasterObserver`) produce the expected latency and outstanding peak; a
+  never-completed (stuck) transaction is surfaced, not silently dropped.
+- `RouterPerfObserver`: a fed `Router` with a forced `credit==0` and a non-empty
+  input FIFO whose front flit routes to that output accrues credit-stall cycles;
+  an idle router (or `credit==0` with no front flit demanding that output)
+  accrues zero.
+- `AxiMaster` multi-subscriber callbacks: registering two `on_write_completed`
+  callbacks fires both, in order (guards the H1 fix so a future caller cannot
+  silently regress to overwrite semantics).
+- Non-intrusive A/B integration test in `test_router_loopback.cpp`: run the
+  scenario once without observers and once with, and assert the loop's final
+  `cycle` count and the scoreboard mismatch count are identical. This is the
+  concrete check that sampling/callbacks do not perturb DUT timing.
+
+## 9. Scope boundary
+
+In scope: two testbench-only observers, shared helpers, AxiMaster issue
+callbacks, Rob occupancy getter, JSON/stdout telemetry, `test_router_loopback`
+integration.
+
+Out of scope (non-goals this round):
+
+- QoS / per-QoS breakdown -- NoC does not consume AXI `awqos`/`arqos`; `noc_qos`
+  is field-only, unimplemented (`nmu/packetize.hpp:23`).
+- CSR register model -- telemetry only; CSR shape (CXL CPMU style) deferred.
+- Layer-1 BFM end-to-end latency observer -- add later to decompose master-queue
+  vs NI vs fabric.
+- Deep congestion (wormhole-lock / arbitration-loss attribution) -- needs
+  `Router::tick` event hooks (production change), deferred.
+- Credit-RTT modeling gap -- the NMU/NSU edge pulse credit lacks credit-RTT
+  accounting; this is a router/credit-model item, not a probe item.
+- ChannelModel-path telemetry -- numbers there are non-physical; observers target
+  the real Router path.
+
+## 10. References
+
+- `c_model/tests/common/test_logger.hpp` -- `AxiMasterObserver` (the
+  non-intrusive observer pattern this design follows).
+- `c_model/include/axi/scoreboard.hpp` -- `Scoreboard` (per-run aggregate +
+  report pattern).
+- `c_model/include/noc/router.hpp` -- `Router` introspection accessors.
+- `c_model/include/nmu/nmu.hpp` -- `Nmu::rob()` / `vc_arbiter()` introspection.
+- BookSim2 (Jiang et al., ISPASS 2013) -- `TrafficManager` three-phase
+  measurement, `_RetireFlit` tail-retirement latency, `stats.hpp`.
+- EP2724234A2 -- programmable threshold-bin latency histogram.
+```

--- a/docs/superpowers/specs/2026-06-17-ni-router-perf-observer-design.md
+++ b/docs/superpowers/specs/2026-06-17-ni-router-perf-observer-design.md
@@ -1,7 +1,7 @@
 # NI + Router Performance Observer Design
 
 Date: 2026-06-17
-Status: Draft (pending Codex review + user review)
+Status: Implemented (2026-06-17, branch feat/ni-router-perf-observer)
 Scope: two testbench-only, non-intrusive performance observers for the c_model
 NoC -- `NIPerfObserver` (NI-edge latency / outstanding / RoB occupancy) and
 `RouterPerfObserver` (credit-stall / FIFO occupancy / output-port congestion) --


### PR DESCRIPTION
## Summary

Adds two **testbench-only, non-intrusive** performance observers for the c_model NoC, with shared helpers and a report writer. Telemetry only — no CSR model.

- **`NIPerfObserver`** — NI-edge latency histogram + outstanding depth + RoB occupancy + per-ID, driven by AxiMaster issue/completion callbacks and a RoB-occupancy probe (one instance per NMU).
- **`RouterPerfObserver`** — credit-stall cycles + per-VC/FIFO occupancy + output-port non-empty ratio, polling `const Router*` introspection (all 4 `TwoNodeFabric` routers).
- **Shared:** `Stats` (count/min/max/mean/variance + threshold-bin histogram, BookSim2-style), `PhaseController` (warmup/measurement/drain), `PerfReport` (stdout summary + `NOC_PERF=1` JSON).

All observers live under `c_model/tests/common/` (`ni::cmodel::testing`); none are linked into production.

## Production changes (additive / const / append-only)

| Change | File |
|---|---|
| Multi-subscriber completion callbacks + `on_*_issued` issue hooks + `IssueInfo` | `c_model/include/axi/axi_master.hpp` |
| `Rob::write_occupancy()` / `read_occupancy()` introspection | `c_model/include/nmu/rob.hpp` |
| `Router::front_route()` / `num_vc()` introspection | `c_model/include/noc/router.hpp` |

No behavior change for existing callers (single-registration audited; append preserves it).

## Design / process

- Design spec: `docs/superpowers/specs/2026-06-17-ni-router-perf-observer-design.md`
- Plan: `docs/superpowers/plans/2026-06-17-ni-router-perf-observer.md`
- Survey (Arteris/Qualcomm latency-probe patent, Goossens/Ciordas NoC monitoring, BookSim2 methodology) → spec → Codex review (4 HIGH fixed) → plan → Codex plan review (4 must-fix) → subagent-driven TDD execution → final whole-branch review (passed).

## Test status

- **Full ctest: 536/536 pass, 0 fail** (1 expected INF-001 skip); build clean.
- Non-intrusive A/B test (`RouterLoopbackPerf.ObserversAreNonIntrusive`) proves identical cycle-to-completion with vs without observers against the real router fabric.
- ~17 new tests (Stats, PhaseController, both observers, PerfReport, the three production hooks, loopback integration), all TDD RED→GREEN.

## Note

`make check` currently fails only at `lint_docs` on a **pre-existing** non-ASCII em-dash in `docs/development.md` (present on `main`, untouched by this branch). Out of scope here; flagging so CI/reviewers aren't surprised.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
