### PR TITLE
docs(dv): require hybrid block cosimulation

### DIFF
--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -5,8 +5,8 @@ merges follow implementation dependencies from verified leaf units back to each 
 issue IDs and readiness are maintained in the campaign issue graph; this file records stage gates.
 
 ## Stage 1: Top-Level Contract
-Goal: Freeze the NMU, NSU, and Router hierarchy, interfaces, clock/reset ownership, canonical RTL parameters, and model/RTL DUT selection.
-Success Criteria: The three block contracts are reviewed against their specs and wrappers; parameter names, defaults, and legal ranges have one canonical source; `codegen.py --check` passes; no placeholder RTL is committed.
+Goal: Freeze the NMU, NSU, and Router hierarchy, interfaces, clock/reset ownership, canonical RTL parameters, and independent per-block model/RTL DUT selection.
+Success Criteria: The three block contracts are reviewed against their specs and wrappers; NMU, NSU, and Router can each select model or RTL without exposing DPI handles to production RTL; parameter names, defaults, and legal ranges have one canonical source; `codegen.py --check` passes; no placeholder RTL is committed.
 Status: Not Started
 
 ## Stage 2: Shared Foundation And DV Plans
@@ -16,7 +16,7 @@ Status: Not Started
 
 ## Stage 3: Block RTL
 Goal: Implement and verify Router, NMU, and NSU through independently reviewable work packages.
-Success Criteria: Every DE package has its paired DV evidence; focused tests pass from a clean tree; Router, NMU, and NSU elaborate through the wrapper-facing RTL contract; reference reuse is classified and license-compliant.
+Success Criteria: Every DE package has its paired DV evidence; focused tests pass from a clean tree; RTL NMU passes zero-hop co-sim with the reference NSU; RTL NSU passes zero-hop co-sim with the reference NMU; any model/target DAT flow-control mismatch is isolated in a verification-only adapter with no packet transformation; RTL Router passes its reference-driven differential harness within the documented conformance scope; Router, NMU, and NSU elaborate through the wrapper-facing RTL contract; reference reuse is classified and license-compliant.
 Status: Not Started
 
 ## Stage 4: 2x2 Integration

--- a/docs/verification-environment.md
+++ b/docs/verification-environment.md
@@ -95,6 +95,28 @@ directed driver --> master_dv --> NMU --> routers --> NSU --> slave_dv --> tile-
 Every node carries the same endpoint layout; the fabric and the NI wraps
 (`ni_wrap`, `router_wrap`) hold no verification code.
 
+### Hybrid block co-simulation
+
+RTL block signoff does not wait for a complete RTL mesh. The verification composition selects the
+NMU, NSU and Router implementations independently. A model selection instantiates the existing DPI
+wrapper and consumes its `ctx` handle; an RTL selection instantiates the synthesizable block with the
+same functional ports and has no DPI handle.
+
+The NI hybrid tests use a zero-hop test link. RTL NMU connects to the reference NSU, and reference
+NMU connects to RTL NSU. REQ and RSP use their ready/valid contracts directly. Where the current
+model's symmetric DAT credit port differs from the target Router-to-NI ready/valid contract, a
+verification-only adapter translates flow control without changing the flit, adding routing, or
+modeling a Router pipeline. This verifies AXI-to-flit, flit-to-AXI, ordering, backpressure and
+response behavior without requiring any Router or mesh.
+
+Router block signoff uses identical flit, ready and credit stimulus against RTL and reference Router
+instances and compares outputs only inside the approved conformance matrix. Documented intentional
+cycle differences, including the current model's optimistic collective multi-output behavior, are
+excluded explicitly rather than hidden by loose scoreboarding.
+
+The acceptance order is unit DV, hybrid block co-sim, full-RTL `2x2 verify`, then the full-RTL
+`4x4 verify` milestone. Every ready/valid hybrid boundary receives randomized stall injection.
+
 ## VIP set
 
 All four components are vendored under `sim/dv/` and run unmodified except

--- a/rtl/README.md
+++ b/rtl/README.md
@@ -1,28 +1,33 @@
-# rtl — synthesisable RTL
+# RTL - synthesizable RTL
 
 Empty until the RTL is written. One directory per block, matching the c_model's
 sub-namespaces: `nmu/`, `nsu/`, `router/`, plus `common/` for anything shared.
 
 ## The port contract
 
-One testbench serves both DUTs. `sim/tb/` drives the C++ behavioural model today
-through the DPI wrappers in `ref_model/top/`, and will drive the RTL through the
-same ports, so **a block's RTL takes the port list its wrapper already has**:
+One verification environment serves model, RTL, and hybrid compositions. `sim/tb/`
+drives the C++ behavioural model today through the DPI wrappers in `ref_model/top/`,
+and will drive RTL through the same ports, so **a block's RTL takes the functional
+port list its wrapper already has**:
 
-| block | the wrapper that fixes the ports |
+| block | wrapper that fixes the functional ports |
 |---|---|
 | NMU | `ref_model/top/nmu_wrap.sv` |
 | NSU | `ref_model/top/nsu_wrap.sv` |
-| router | `ref_model/top/router_wrap.sv` |
+| Router | `ref_model/top/router_wrap.sv` |
 
-The wrappers carry a `longint unsigned ctx` handle that the RTL will not have,
-and that is the one difference to resolve when the first block lands — either
-the RTL ignores it or the tb selects between two instantiations. Everything
-else, the AXI faces and the NoC link faces, is the contract.
+The wrappers carry a `longint unsigned ctx` handle that RTL does not have. The
+testbench selects model or RTL independently for NMU, NSU, and Router; only the
+model branch consumes the handle. Production RTL must not expose or ignore a dummy
+DPI handle. The AXI faces and NoC link faces are the shared contract.
 
 ## Why it matters
 
-Same stimulus, same seed, both DUTs: `sim/tools/gen_test_patterns.py` produces
-one set of files and either DUT replays it. That is what makes the C++ model a
-*reference* model rather than a separate implementation — RTL output can be
-compared against it beat for beat instead of only against a scoreboard.
+Same stimulus, same seed, mixed implementations: `sim/tools/gen_test_patterns.py`
+produces one set of files. Before a full RTL mesh, block signoff uses RTL NMU with
+reference NSU, reference NMU with RTL NSU, and a reference-driven differential
+Router harness. The NMU/NSU pair uses a zero-hop test link. REQ and RSP connect
+directly; a verification-only DAT adapter translates flow control where the
+current model's credit port differs from the target ready/valid contract. The
+adapter does not transform packets or implement Router behavior. Full-model and
+full-RTL runs remain available for end-to-end comparison and milestone regression.


### PR DESCRIPTION
## Summary
- require block-level hybrid RTL/reference co-simulation before mesh integration
- define independent NMU, NSU, and Router implementation selection
- define zero-hop NI pairing and verification-only DAT flow-control adaptation

## Verification
- `git diff --check main...HEAD`
- doc-only change; no compile or simulation required by the standing gate
- GitHub issues #9, #10, #11, #12, #20, #26, and #30 carry the same hybrid requirement