### PR TITLE
chore(agent): configure approved RTL references

### DIFF
--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -10,8 +10,8 @@ Success Criteria: The three block contracts are reviewed against their specs and
 Status: Not Started
 
 ## Stage 2: Shared Foundation And DV Plans
-Goal: Verify the shared FIFO/register primitives and approve one verification plan for each major block.
-Success Criteria: FIFO, AXI async FIFO, and register-slice tests pass across legal modes; Router, NMU, and NSU DV plans identify assertions, reference-model obligations, coverage, provenance, and per-package acceptance evidence.
+Goal: Integrate and verify the pinned common_cells FIFO/register primitives and approve one verification plan for each major block.
+Success Criteria: Project adapters for the synchronous FIFO, AXI async FIFO, and register primitives pass across legal modes without reimplementing the library; Router, NMU, and NSU DV plans identify assertions, reference-model obligations, coverage, provenance, and per-package acceptance evidence.
 Status: Not Started
 
 ## Stage 3: Block RTL

--- a/ic-team.config.mts
+++ b/ic-team.config.mts
@@ -1,0 +1,27 @@
+const flooNoCPath = process.env.FLOONOC_REFERENCE ?? "E:/05_NoC/FlooNoC";
+const taxiPath = process.env.TAXI_REFERENCE ?? "E:/03_Learning/taxi";
+
+export default {
+  image: "ic-design-team:latest",
+  baseBranch: "main",
+  maxParallel: 1,
+  references: [
+    {
+      name: "FlooNoC",
+      path: flooNoCPath,
+      policy: "production-approved",
+    },
+    {
+      name: "Taxi",
+      path: taxiPath,
+      policy: "reference-only",
+    },
+  ],
+  verification: [
+    {
+      name: "baseline",
+      clean: "make clean-generated",
+      command: "python3 specgen/tools/codegen.py --check && git diff --check",
+    },
+  ],
+};


### PR DESCRIPTION
## Summary
- mount FlooNoC as production-approved and Taxi as reference-only
- use a clean codegen baseline gate
- require common_cells integration instead of custom FIFO RTL

## Verification
- python specgen/tools/codegen.py --check
- git diff --check