### PR TITLE
agent: F1-DE: Integrate common_cells FIFO, CDC, and register primitives

### DIFF
--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -12,7 +12,7 @@ Status: Complete
 ## Stage 2: Shared Foundation And DV Plans
 Goal: Integrate and verify the pinned common_cells FIFO/register primitives and approve one verification plan for each major block.
 Success Criteria: Project adapters for the synchronous FIFO, AXI async FIFO, and register primitives pass across legal modes without reimplementing the library; Router, NMU, and NSU DV plans identify assertions, reference-model obligations, coverage, provenance, and per-package acceptance evidence.
-Status: Not Started
+Status: In Progress
 
 ## Stage 3: Block RTL
 Goal: Implement and verify Router, NMU, and NSU through independently reviewable work packages.

--- a/Makefile
+++ b/Makefile
@@ -238,6 +238,7 @@ sim-gen:
 clean: clean-cmodel clean-verilator clean-vcs clean-generated
 	rm -rf $(BUILD_ROOT)
 	rm -f master_wrap_read_dump*.txt
+	rm -f core core.*
 
 clean-cmodel:
 	rm -rf $(CMODEL_BUILD)

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ CMODEL_BUILD     = $(BUILD_ROOT)/cmodel
 SIM_VERILATOR := sim/verilator
 SIM_VCS       := sim/vcs
 
-.PHONY: help build build-cmodel build-yamlcpp build-verilator test \
+.PHONY: help build build-cmodel build-yamlcpp build-verilator test rtl-common-lint rtl-common-test \
         pytest check docker-build docker-shell docker-test docker-pytest docker-sim-setup docker-sim-smoke docker-sim-tier2 \
         clean clean-cmodel clean-verilator clean-vcs clean-generated
 
@@ -38,6 +38,8 @@ help:
 	@echo ""
 	@echo "Test:"
 	@echo "  make test             run c_model ctest suite"
+	@echo "  make rtl-common-lint  lint the production common primitive adapters"
+	@echo "  make rtl-common-test  lint and behavior-test the common primitive adapters"
 	@echo "  make pytest           specgen + sim/tools suites, golden drift gate"
 	@echo "  make check            both of the above -- run this before committing"
 	@echo ""
@@ -140,6 +142,12 @@ build-verilator: build-yamlcpp
 
 test: build-cmodel
 	@cd $(CMODEL_BUILD) && ctest --output-on-failure
+
+rtl-common-lint:
+	@bash rtl/common/test.sh lint
+
+rtl-common-test:
+	@bash rtl/common/test.sh test
 
 PYTHON3 ?= python3
 

--- a/rtl/Bender.yml
+++ b/rtl/Bender.yml
@@ -7,3 +7,8 @@ dependencies:
   common_cells:
     git: https://github.com/pulp-platform/common_cells.git
     rev: 9ca8a7655f741e7dd5736669a20a301325194c28
+
+sources:
+  - common/noc_sync_fifo.sv
+  - common/axi_async_fifo.sv
+  - common/noc_reg_slice.sv

--- a/rtl/common/axi_async_fifo.sv
+++ b/rtl/common/axi_async_fifo.sv
@@ -23,16 +23,16 @@ module axi_async_fifo #(
     output wire T      dst_data_o
 );
 
-    localparam int unsigned LOG_DEPTH = $clog2(AXI_FIFO_DEPTH);
+    localparam int unsigned CL_AXI_FIFO_DEPTH = $clog2(AXI_FIFO_DEPTH);
 
     if (AXI_FIFO_DEPTH != 4 && AXI_FIFO_DEPTH != 8 && AXI_FIFO_DEPTH != 16) begin : gen_invalid_depth
         initial $fatal(0, "Error: AXI_FIFO_DEPTH must be 4, 8, or 16 (instance %m)");
     end
 
     cdc_fifo_gray #(
-        .T          ( T         ),
-        .LOG_DEPTH  ( LOG_DEPTH ),
-        .SYNC_STAGES( 2         )
+        .T           ( T                 ),
+        .LOG_DEPTH   ( CL_AXI_FIFO_DEPTH ),
+        .SYNC_STAGES ( 2                 )
     ) i_cdc_fifo_gray (
         .src_rst_ni,
         .src_clk_i,

--- a/rtl/common/axi_async_fifo.sv
+++ b/rtl/common/axi_async_fifo.sv
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: Apache-2.0
+
+`resetall
+`timescale 1ns / 1ps
+`default_nettype none
+
+/* Ready/valid adapter for the production Gray-pointer CDC FIFO primitive. */
+module axi_async_fifo #(
+    // AXI channel FIFO depth in entries.
+    parameter int unsigned AXI_FIFO_DEPTH = 8,
+    // Complete AXI channel record type.
+    parameter type T = logic
+) (
+    input  wire logic  src_clk_i,
+    input  wire logic  src_rst_ni,
+    input  wire logic  src_valid_i,
+    output wire logic  src_ready_o,
+    input  wire T      src_data_i,
+    input  wire logic  dst_clk_i,
+    input  wire logic  dst_rst_ni,
+    output wire logic  dst_valid_o,
+    input  wire logic  dst_ready_i,
+    output wire T      dst_data_o
+);
+
+    localparam int unsigned LOG_DEPTH = $clog2(AXI_FIFO_DEPTH);
+
+    if (AXI_FIFO_DEPTH != 4 && AXI_FIFO_DEPTH != 8 && AXI_FIFO_DEPTH != 16) begin : gen_invalid_depth
+        initial $fatal(0, "Error: AXI_FIFO_DEPTH must be 4, 8, or 16 (instance %m)");
+    end
+
+    cdc_fifo_gray #(
+        .T          ( T         ),
+        .LOG_DEPTH  ( LOG_DEPTH ),
+        .SYNC_STAGES( 2         )
+    ) i_cdc_fifo_gray (
+        .src_rst_ni,
+        .src_clk_i,
+        .src_data_i,
+        .src_valid_i,
+        .src_ready_o,
+        .dst_rst_ni,
+        .dst_clk_i,
+        .dst_data_o,
+        .dst_valid_o,
+        .dst_ready_i
+    );
+
+endmodule
+
+`resetall

--- a/rtl/common/noc_reg_slice.sv
+++ b/rtl/common/noc_reg_slice.sv
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: Apache-2.0
+
+`resetall
+`timescale 1ns / 1ps
+`default_nettype none
+
+/* Ready/valid adapter selecting bypass, simple, or spill register storage. */
+module noc_reg_slice #(
+    // 0: bypass, 1: simple register, 2: full spill register.
+    parameter int unsigned REG_TYPE = 0,
+    // Complete transaction record type.
+    parameter type T = logic
+) (
+    input  wire logic  clk_i,
+    input  wire logic  rst_ni,
+    input  wire logic  s_valid_i,
+    output wire logic  s_ready_o,
+    input  wire T      s_data_i,
+    output wire logic  m_valid_o,
+    input  wire logic  m_ready_i,
+    output wire T      m_data_o
+);
+
+    if (REG_TYPE > 2) begin : gen_invalid_reg_type
+        initial $fatal(0, "Error: REG_TYPE must be 0, 1, or 2 (instance %m)");
+    end
+
+    if (REG_TYPE == 0) begin : gen_bypass
+        assign s_ready_o = m_ready_i;
+        assign m_valid_o = s_valid_i;
+        assign m_data_o = s_data_i;
+    end else if (REG_TYPE == 1) begin : gen_simple
+        stream_register #(
+            .T ( T )
+        ) i_stream_register (
+            .clk_i,
+            .rst_ni,
+            .clr_i      ( 1'b0      ),
+            .testmode_i ( 1'b0      ),
+            .valid_i    ( s_valid_i ),
+            .ready_o    ( s_ready_o ),
+            .data_i     ( s_data_i  ),
+            .valid_o    ( m_valid_o ),
+            .ready_i    ( m_ready_i ),
+            .data_o     ( m_data_o  )
+        );
+    end else begin : gen_spill
+        spill_register #(
+            .T ( T )
+        ) i_spill_register (
+            .clk_i,
+            .rst_ni,
+            .valid_i ( s_valid_i ),
+            .ready_o ( s_ready_o ),
+            .data_i  ( s_data_i  ),
+            .valid_o ( m_valid_o ),
+            .ready_i ( m_ready_i ),
+            .data_o  ( m_data_o  )
+        );
+    end
+
+endmodule
+
+`resetall

--- a/rtl/common/noc_sync_fifo.sv
+++ b/rtl/common/noc_sync_fifo.sv
@@ -21,7 +21,8 @@ module noc_sync_fifo #(
     output wire T      m_data_o
 );
 
-    localparam int unsigned FIFO_ADDR_W = NOC_FIFO_DEPTH > 1 ? $clog2(NOC_FIFO_DEPTH) : 1;
+    localparam int unsigned CL_NOC_FIFO_DEPTH =
+        NOC_FIFO_DEPTH > 1 ? $clog2(NOC_FIFO_DEPTH) : 1;
 
     if (NOC_FIFO_DEPTH != 4 && NOC_FIFO_DEPTH != 8 && NOC_FIFO_DEPTH != 16) begin : gen_invalid_depth
         initial $fatal(0, "Error: NOC_FIFO_DEPTH must be 4, 8, or 16 (instance %m)");
@@ -29,7 +30,7 @@ module noc_sync_fifo #(
 
     logic fifo_full;
     logic fifo_empty;
-    logic [FIFO_ADDR_W-1:0] fifo_usage;
+    logic [CL_NOC_FIFO_DEPTH-1:0] fifo_usage;
 
     fifo_v3 #(
         .FALL_THROUGH ( 1'b0           ),

--- a/rtl/common/noc_sync_fifo.sv
+++ b/rtl/common/noc_sync_fifo.sv
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: Apache-2.0
+
+`resetall
+`timescale 1ns / 1ps
+`default_nettype none
+
+/* Ready/valid adapter for the production synchronous FIFO primitive. */
+module noc_sync_fifo #(
+    // NoC class FIFO depth in entries.
+    parameter int unsigned NOC_FIFO_DEPTH = 8,
+    // Complete transaction record type.
+    parameter type T = logic
+) (
+    input  wire logic  clk_i,
+    input  wire logic  rst_ni,
+    input  wire logic  s_valid_i,
+    output wire logic  s_ready_o,
+    input  wire T      s_data_i,
+    output wire logic  m_valid_o,
+    input  wire logic  m_ready_i,
+    output wire T      m_data_o
+);
+
+    localparam int unsigned FIFO_ADDR_W = NOC_FIFO_DEPTH > 1 ? $clog2(NOC_FIFO_DEPTH) : 1;
+
+    if (NOC_FIFO_DEPTH != 4 && NOC_FIFO_DEPTH != 8 && NOC_FIFO_DEPTH != 16) begin : gen_invalid_depth
+        initial $fatal(0, "Error: NOC_FIFO_DEPTH must be 4, 8, or 16 (instance %m)");
+    end
+
+    logic fifo_full;
+    logic fifo_empty;
+    logic [FIFO_ADDR_W-1:0] fifo_usage;
+
+    fifo_v3 #(
+        .FALL_THROUGH ( 1'b0           ),
+        .DEPTH        ( NOC_FIFO_DEPTH ),
+        .dtype        ( T              )
+    ) i_fifo_v3 (
+        .clk_i,
+        .rst_ni,
+        .flush_i    ( 1'b0                 ),
+        .testmode_i ( 1'b0                 ),
+        .full_o     ( fifo_full            ),
+        .empty_o    ( fifo_empty           ),
+        .usage_o    ( fifo_usage           ),
+        .data_i     ( s_data_i             ),
+        .push_i     ( s_valid_i & s_ready_o ),
+        .data_o     ( m_data_o             ),
+        .pop_i      ( m_valid_o & m_ready_i )
+    );
+
+    // The non-fall-through primitive owns all queue state.
+    assign s_ready_o = !fifo_full;
+    assign m_valid_o = !fifo_empty;
+
+endmodule
+
+`resetall

--- a/rtl/common/test.sh
+++ b/rtl/common/test.sh
@@ -36,7 +36,7 @@ task_sources=(
 
 task_verilator=(
     verilator --timing --assert -Wall -Wno-fatal -Wno-DECLFILENAME -Wno-TIMESCALEMOD
-    -Wno-UNUSEDPARAM -Wno-UNUSEDSIGNAL -DCOMMON_CELLS_ASSERTS_OFF
+    -Wno-UNUSEDPARAM -Wno-UNUSEDSIGNAL -Wno-SYNCASYNCNET
     -I"$task_common_cells/include" --top-module tb_common_primitives
 )
 

--- a/rtl/common/test.sh
+++ b/rtl/common/test.sh
@@ -46,9 +46,15 @@ case "$task_mode" in
         ;;
     test)
         "${task_verilator[@]}" --lint-only "${task_sources[@]}"
-        "${task_verilator[@]}" --binary --Mdir "$task_tmp/obj_dir" -o common_primitives_tb \
-            "${task_sources[@]}"
-        "$task_tmp/obj_dir/common_primitives_tb"
+        for task_depth in 4 8 16; do
+            task_obj_dir="$task_tmp/obj_dir_$task_depth"
+            "${task_verilator[@]}" \
+                -GNOC_FIFO_DEPTH="$task_depth" \
+                -GAXI_FIFO_DEPTH="$task_depth" \
+                --binary --Mdir "$task_obj_dir" -o common_primitives_tb \
+                "${task_sources[@]}"
+            "$task_obj_dir/common_primitives_tb"
+        done
         ;;
     *)
         echo "usage: $0 [lint|test]" >&2

--- a/rtl/common/test.sh
+++ b/rtl/common/test.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+task_mode=${1:-test}
+task_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
+task_manifest="$task_root/rtl/Bender.yml"
+task_revision=9ca8a7655f741e7dd5736669a20a301325194c28
+task_tmp=$(mktemp -d "${TMPDIR:-/tmp}/noc-common-primitives-XXXXXX")
+trap 'rm -rf "$task_tmp"' EXIT
+
+if [[ -n "${COMMON_CELLS_DIR:-}" ]]; then
+    task_common_cells=$COMMON_CELLS_DIR
+else
+    task_common_cells="$task_tmp/common_cells"
+    git clone --quiet https://github.com/pulp-platform/common_cells.git "$task_common_cells"
+    git -C "$task_common_cells" checkout --quiet "$task_revision"
+fi
+
+[[ $(git -C "$task_common_cells" rev-parse HEAD) == "$task_revision" ]]
+grep -Fq "$task_revision" "$task_manifest"
+
+task_sources=(
+    "$task_common_cells/src/binary_to_gray.sv"
+    "$task_common_cells/src/fifo_v3.sv"
+    "$task_common_cells/src/gray_to_binary.sv"
+    "$task_common_cells/src/spill_register_flushable.sv"
+    "$task_common_cells/src/spill_register.sv"
+    "$task_common_cells/src/stream_register.sv"
+    "$task_common_cells/src/sync.sv"
+    "$task_common_cells/src/cdc_fifo_gray.sv"
+    "$task_root/rtl/common/noc_sync_fifo.sv"
+    "$task_root/rtl/common/axi_async_fifo.sv"
+    "$task_root/rtl/common/noc_reg_slice.sv"
+    "$task_root/rtl/common/tests/tb_common_primitives.sv"
+)
+
+task_verilator=(
+    verilator --timing --assert -Wall -Wno-fatal -Wno-DECLFILENAME -Wno-TIMESCALEMOD
+    -Wno-UNUSEDPARAM -Wno-UNUSEDSIGNAL -DCOMMON_CELLS_ASSERTS_OFF
+    -I"$task_common_cells/include" --top-module tb_common_primitives
+)
+
+case "$task_mode" in
+    lint)
+        "${task_verilator[@]}" --lint-only "${task_sources[@]}"
+        ;;
+    test)
+        "${task_verilator[@]}" --lint-only "${task_sources[@]}"
+        "${task_verilator[@]}" --binary --Mdir "$task_tmp/obj_dir" -o common_primitives_tb \
+            "${task_sources[@]}"
+        "$task_tmp/obj_dir/common_primitives_tb"
+        ;;
+    *)
+        echo "usage: $0 [lint|test]" >&2
+        exit 2
+        ;;
+esac

--- a/rtl/common/tests/tb_common_primitives.sv
+++ b/rtl/common/tests/tb_common_primitives.sv
@@ -1,0 +1,260 @@
+`resetall
+`timescale 1ns / 1ps
+`default_nettype none
+
+module tb_common_primitives;
+
+    logic clk_i = 1'b0;
+    logic src_clk_i = 1'b0;
+    logic dst_clk_i = 1'b0;
+    logic rst_ni = 1'b0;
+
+    logic       sync_s_valid;
+    logic       sync_s_ready;
+    logic [7:0] sync_s_data;
+    logic       sync_m_valid;
+    logic       sync_m_ready;
+    logic [7:0] sync_m_data;
+
+    logic       cdc_s_valid;
+    logic       cdc_s_ready;
+    logic [7:0] cdc_s_data;
+    logic       cdc_m_valid;
+    logic       cdc_m_ready;
+    logic [7:0] cdc_m_data;
+
+    logic       bypass_s_valid;
+    logic       bypass_s_ready;
+    logic [7:0] bypass_s_data;
+    logic       bypass_m_valid;
+    logic       bypass_m_ready;
+    logic [7:0] bypass_m_data;
+
+    logic       simple_s_valid;
+    logic       simple_s_ready;
+    logic [7:0] simple_s_data;
+    logic       simple_m_valid;
+    logic       simple_m_ready;
+    logic [7:0] simple_m_data;
+
+    logic       skid_s_valid;
+    logic       skid_s_ready;
+    logic [7:0] skid_s_data;
+    logic       skid_m_valid;
+    logic       skid_m_ready;
+    logic [7:0] skid_m_data;
+
+    noc_sync_fifo #(
+        .T              ( logic [7:0] ),
+        .NOC_FIFO_DEPTH ( 4            )
+    ) i_noc_sync_fifo (
+        .clk_i,
+        .rst_ni,
+        .s_valid_i ( sync_s_valid ),
+        .s_ready_o ( sync_s_ready ),
+        .s_data_i  ( sync_s_data  ),
+        .m_valid_o ( sync_m_valid ),
+        .m_ready_i ( sync_m_ready ),
+        .m_data_o  ( sync_m_data  )
+    );
+
+    axi_async_fifo #(
+        .T              ( logic [7:0] ),
+        .AXI_FIFO_DEPTH ( 4            )
+    ) i_axi_async_fifo (
+        .src_clk_i,
+        .src_rst_ni  ( rst_ni      ),
+        .src_valid_i ( cdc_s_valid ),
+        .src_ready_o ( cdc_s_ready ),
+        .src_data_i  ( cdc_s_data  ),
+        .dst_clk_i,
+        .dst_rst_ni  ( rst_ni      ),
+        .dst_valid_o ( cdc_m_valid ),
+        .dst_ready_i ( cdc_m_ready ),
+        .dst_data_o  ( cdc_m_data  )
+    );
+
+    noc_reg_slice #(
+        .T        ( logic [7:0] ),
+        .REG_TYPE ( 0            )
+    ) i_noc_reg_slice_bypass (
+        .clk_i,
+        .rst_ni,
+        .s_valid_i ( bypass_s_valid ),
+        .s_ready_o ( bypass_s_ready ),
+        .s_data_i  ( bypass_s_data  ),
+        .m_valid_o ( bypass_m_valid ),
+        .m_ready_i ( bypass_m_ready ),
+        .m_data_o  ( bypass_m_data  )
+    );
+
+    noc_reg_slice #(
+        .T        ( logic [7:0] ),
+        .REG_TYPE ( 1            )
+    ) i_noc_reg_slice_simple (
+        .clk_i,
+        .rst_ni,
+        .s_valid_i ( simple_s_valid ),
+        .s_ready_o ( simple_s_ready ),
+        .s_data_i  ( simple_s_data  ),
+        .m_valid_o ( simple_m_valid ),
+        .m_ready_i ( simple_m_ready ),
+        .m_data_o  ( simple_m_data  )
+    );
+
+    noc_reg_slice #(
+        .T        ( logic [7:0] ),
+        .REG_TYPE ( 2            )
+    ) i_noc_reg_slice_skid (
+        .clk_i,
+        .rst_ni,
+        .s_valid_i ( skid_s_valid ),
+        .s_ready_o ( skid_s_ready ),
+        .s_data_i  ( skid_s_data  ),
+        .m_valid_o ( skid_m_valid ),
+        .m_ready_i ( skid_m_ready ),
+        .m_data_o  ( skid_m_data  )
+    );
+
+    always #5ns clk_i <= ~clk_i;
+    always #4ns src_clk_i <= ~src_clk_i;
+    always #7ns dst_clk_i <= ~dst_clk_i;
+
+    task automatic sync_send(input logic [7:0] data);
+        begin
+            @(negedge clk_i);
+            sync_s_data = data;
+            sync_s_valid = 1'b1;
+            do @(posedge clk_i); while (!sync_s_ready);
+            @(negedge clk_i);
+            sync_s_valid = 1'b0;
+        end
+    endtask
+
+    task automatic cdc_send(input logic [7:0] data);
+        begin
+            @(negedge src_clk_i);
+            cdc_s_data = data;
+            cdc_s_valid = 1'b1;
+            do @(posedge src_clk_i); while (!cdc_s_ready);
+            @(negedge src_clk_i);
+            cdc_s_valid = 1'b0;
+        end
+    endtask
+
+    task automatic cdc_receive(input logic [7:0] expected);
+        begin
+            wait (cdc_m_valid);
+            assert (cdc_m_data == expected)
+                else $fatal(1, "CDC FIFO expected %0h, got %0h", expected, cdc_m_data);
+            @(posedge dst_clk_i);
+            #1ps;
+        end
+    endtask
+
+    initial begin
+        sync_s_valid = 1'b0;
+        sync_s_data = '0;
+        sync_m_ready = 1'b0;
+        cdc_s_valid = 1'b0;
+        cdc_s_data = '0;
+        cdc_m_ready = 1'b0;
+        bypass_s_valid = 1'b0;
+        bypass_s_data = '0;
+        bypass_m_ready = 1'b0;
+        simple_s_valid = 1'b0;
+        simple_s_data = '0;
+        simple_m_ready = 1'b0;
+        skid_s_valid = 1'b0;
+        skid_s_data = '0;
+        skid_m_ready = 1'b0;
+
+        repeat (3) @(posedge clk_i);
+        rst_ni = 1'b1;
+
+        // The synchronous FIFO is non-fall-through and preserves all four entries.
+        sync_send(8'h10);
+        sync_send(8'h11);
+        sync_send(8'h12);
+        sync_send(8'h13);
+        assert (!sync_s_ready) else $fatal(1, "Synchronous FIFO did not become full");
+        sync_m_ready = 1'b1;
+        wait (sync_m_valid && sync_m_data == 8'h10); @(posedge clk_i);
+        wait (sync_m_valid && sync_m_data == 8'h11); @(posedge clk_i);
+        wait (sync_m_valid && sync_m_data == 8'h12); @(posedge clk_i);
+        wait (sync_m_valid && sync_m_data == 8'h13); @(posedge clk_i);
+        @(negedge clk_i);
+        sync_m_ready = 1'b0;
+        assert (!sync_m_valid) else $fatal(1, "Synchronous FIFO did not drain");
+
+        // The Gray-pointer FIFO crosses unrelated clocks without reordering.
+        cdc_send(8'h20);
+        cdc_send(8'h21);
+        cdc_send(8'h22);
+        cdc_send(8'h23);
+        cdc_m_ready = 1'b1;
+        cdc_receive(8'h20);
+        cdc_receive(8'h21);
+        cdc_receive(8'h22);
+        cdc_receive(8'h23);
+        @(negedge dst_clk_i);
+        cdc_m_ready = 1'b0;
+
+        // Bypass has no storage or added latency.
+        bypass_m_ready = 1'b1;
+        bypass_s_data = 8'h30;
+        bypass_s_valid = 1'b1;
+        #1ns;
+        assert (bypass_s_ready && bypass_m_valid && bypass_m_data == 8'h30)
+            else $fatal(1, "Bypass register slice changed the transaction");
+        @(posedge clk_i);
+        @(negedge clk_i);
+        bypass_s_valid = 1'b0;
+        bypass_m_ready = 1'b0;
+
+        // A simple register holds its transaction during a downstream stall.
+        wait (simple_s_ready);
+        simple_s_data = 8'h40;
+        simple_s_valid = 1'b1;
+        @(posedge clk_i);
+        @(negedge clk_i);
+        simple_s_valid = 1'b0;
+        wait (simple_m_valid);
+        repeat (3) begin
+            assert (simple_m_data == 8'h40)
+                else $fatal(1, "Simple register did not hold stalled data");
+            @(posedge clk_i);
+        end
+        simple_m_ready = 1'b1;
+        @(posedge clk_i);
+        @(negedge clk_i);
+        simple_m_ready = 1'b0;
+        assert (!simple_m_valid) else $fatal(1, "Simple register did not retire data");
+
+        // A skid buffer accepts two transactions while its output remains stalled.
+        wait (skid_s_ready);
+        skid_s_data = 8'h50;
+        skid_s_valid = 1'b1;
+        @(posedge clk_i);
+        @(negedge clk_i);
+        skid_s_data = 8'h51;
+        @(posedge clk_i);
+        @(negedge clk_i);
+        skid_s_valid = 1'b0;
+        assert (skid_m_valid && skid_m_data == 8'h50)
+            else $fatal(1, "Skid buffer did not retain its first transaction");
+        skid_m_ready = 1'b1;
+        @(posedge clk_i);
+        wait (skid_m_valid && skid_m_data == 8'h51);
+        @(posedge clk_i);
+        @(negedge clk_i);
+        skid_m_ready = 1'b0;
+        assert (!skid_m_valid) else $fatal(1, "Skid buffer did not drain");
+
+        $display("PASS: common primitive adapters");
+        $finish;
+    end
+
+endmodule
+
+`resetall

--- a/rtl/common/tests/tb_common_primitives.sv
+++ b/rtl/common/tests/tb_common_primitives.sv
@@ -11,6 +11,8 @@ module tb_common_primitives #(
     logic src_clk_i = 1'b0;
     logic dst_clk_i = 1'b0;
     logic rst_ni = 1'b0;
+    logic src_rst_ni = 1'b0;
+    logic dst_rst_ni = 1'b0;
 
     logic       sync_s_valid;
     logic       sync_s_ready;
@@ -66,12 +68,12 @@ module tb_common_primitives #(
         .AXI_FIFO_DEPTH ( AXI_FIFO_DEPTH )
     ) i_axi_async_fifo (
         .src_clk_i,
-        .src_rst_ni  ( rst_ni      ),
+        .src_rst_ni,
         .src_valid_i ( cdc_s_valid ),
         .src_ready_o ( cdc_s_ready ),
         .src_data_i  ( cdc_s_data  ),
         .dst_clk_i,
-        .dst_rst_ni  ( rst_ni      ),
+        .dst_rst_ni,
         .dst_valid_o ( cdc_m_valid ),
         .dst_ready_i ( cdc_m_ready ),
         .dst_data_o  ( cdc_m_data  )
@@ -123,6 +125,11 @@ module tb_common_primitives #(
     always #4ns src_clk_i <= ~src_clk_i;
     always #7ns dst_clk_i <= ~dst_clk_i;
 
+    initial begin
+        #100us;
+        $fatal(1, "Timed out waiting for common primitive test completion");
+    end
+
     function automatic logic [7:0] sequence_data(
         input logic [7:0] base,
         input int unsigned index
@@ -162,6 +169,16 @@ module tb_common_primitives #(
         end
     endtask
 
+    task automatic sync_receive(input logic [7:0] expected);
+        begin
+            wait (sync_m_valid);
+            assert (sync_m_data == expected)
+                else $fatal(1, "Synchronous FIFO expected %0h, got %0h", expected, sync_m_data);
+            @(posedge clk_i);
+            #1ps;
+        end
+    endtask
+
     initial begin
         sync_s_valid = 1'b0;
         sync_s_data = '0;
@@ -180,16 +197,32 @@ module tb_common_primitives #(
         skid_m_ready = 1'b0;
 
         repeat (3) @(posedge clk_i);
+        #1ps;
         rst_ni = 1'b1;
+        @(posedge src_clk_i);
+        #1ps;
+        src_rst_ni = 1'b1;
+        repeat (2) @(posedge dst_clk_i);
+        #1ps;
+        dst_rst_ni = 1'b1;
+
+        assert (!sync_m_valid && !cdc_m_valid && !simple_m_valid && !skid_m_valid)
+            else $fatal(1, "Primitive output valid was not cleared by reset");
 
         // The synchronous FIFO is non-fall-through and preserves every entry.
         for (int unsigned index = 0; index < NOC_FIFO_DEPTH; index++) begin
             sync_send(sequence_data(8'h10, index));
         end
         assert (!sync_s_ready) else $fatal(1, "Synchronous FIFO did not become full");
+        repeat (3) begin
+            assert (sync_m_valid && sync_m_data == 8'h10)
+                else $fatal(1, "Synchronous FIFO changed its stalled head transaction");
+            @(posedge clk_i);
+            #1ps;
+        end
         sync_m_ready = 1'b1;
         for (int unsigned index = 0; index < NOC_FIFO_DEPTH; index++) begin
-            wait (sync_m_valid && sync_m_data == sequence_data(8'h10, index)); @(posedge clk_i);
+            sync_receive(sequence_data(8'h10, index));
         end
         @(negedge clk_i);
         sync_m_ready = 1'b0;
@@ -198,6 +231,13 @@ module tb_common_primitives #(
         // The Gray-pointer FIFO crosses unrelated clocks without reordering.
         for (int unsigned index = 0; index < AXI_FIFO_DEPTH; index++) begin
             cdc_send(sequence_data(8'h20, index));
+        end
+        wait (cdc_m_valid);
+        repeat (3) begin
+            assert (cdc_m_valid && cdc_m_data == 8'h20)
+                else $fatal(1, "CDC FIFO changed its stalled head transaction");
+            @(posedge dst_clk_i);
+            #1ps;
         end
         cdc_m_ready = 1'b1;
         for (int unsigned index = 0; index < AXI_FIFO_DEPTH; index++) begin

--- a/rtl/common/tests/tb_common_primitives.sv
+++ b/rtl/common/tests/tb_common_primitives.sv
@@ -2,7 +2,10 @@
 `timescale 1ns / 1ps
 `default_nettype none
 
-module tb_common_primitives;
+module tb_common_primitives #(
+    parameter int unsigned NOC_FIFO_DEPTH = 4,
+    parameter int unsigned AXI_FIFO_DEPTH = 4
+);
 
     logic clk_i = 1'b0;
     logic src_clk_i = 1'b0;
@@ -46,7 +49,7 @@ module tb_common_primitives;
 
     noc_sync_fifo #(
         .T              ( logic [7:0] ),
-        .NOC_FIFO_DEPTH ( 4            )
+        .NOC_FIFO_DEPTH ( NOC_FIFO_DEPTH )
     ) i_noc_sync_fifo (
         .clk_i,
         .rst_ni,
@@ -60,7 +63,7 @@ module tb_common_primitives;
 
     axi_async_fifo #(
         .T              ( logic [7:0] ),
-        .AXI_FIFO_DEPTH ( 4            )
+        .AXI_FIFO_DEPTH ( AXI_FIFO_DEPTH )
     ) i_axi_async_fifo (
         .src_clk_i,
         .src_rst_ni  ( rst_ni      ),
@@ -120,6 +123,13 @@ module tb_common_primitives;
     always #4ns src_clk_i <= ~src_clk_i;
     always #7ns dst_clk_i <= ~dst_clk_i;
 
+    function automatic logic [7:0] sequence_data(
+        input logic [7:0] base,
+        input int unsigned index
+    );
+        sequence_data = base + 8'(index);
+    endfunction
+
     task automatic sync_send(input logic [7:0] data);
         begin
             @(negedge clk_i);
@@ -172,31 +182,27 @@ module tb_common_primitives;
         repeat (3) @(posedge clk_i);
         rst_ni = 1'b1;
 
-        // The synchronous FIFO is non-fall-through and preserves all four entries.
-        sync_send(8'h10);
-        sync_send(8'h11);
-        sync_send(8'h12);
-        sync_send(8'h13);
+        // The synchronous FIFO is non-fall-through and preserves every entry.
+        for (int unsigned index = 0; index < NOC_FIFO_DEPTH; index++) begin
+            sync_send(sequence_data(8'h10, index));
+        end
         assert (!sync_s_ready) else $fatal(1, "Synchronous FIFO did not become full");
         sync_m_ready = 1'b1;
-        wait (sync_m_valid && sync_m_data == 8'h10); @(posedge clk_i);
-        wait (sync_m_valid && sync_m_data == 8'h11); @(posedge clk_i);
-        wait (sync_m_valid && sync_m_data == 8'h12); @(posedge clk_i);
-        wait (sync_m_valid && sync_m_data == 8'h13); @(posedge clk_i);
+        for (int unsigned index = 0; index < NOC_FIFO_DEPTH; index++) begin
+            wait (sync_m_valid && sync_m_data == sequence_data(8'h10, index)); @(posedge clk_i);
+        end
         @(negedge clk_i);
         sync_m_ready = 1'b0;
         assert (!sync_m_valid) else $fatal(1, "Synchronous FIFO did not drain");
 
         // The Gray-pointer FIFO crosses unrelated clocks without reordering.
-        cdc_send(8'h20);
-        cdc_send(8'h21);
-        cdc_send(8'h22);
-        cdc_send(8'h23);
+        for (int unsigned index = 0; index < AXI_FIFO_DEPTH; index++) begin
+            cdc_send(sequence_data(8'h20, index));
+        end
         cdc_m_ready = 1'b1;
-        cdc_receive(8'h20);
-        cdc_receive(8'h21);
-        cdc_receive(8'h22);
-        cdc_receive(8'h23);
+        for (int unsigned index = 0; index < AXI_FIFO_DEPTH; index++) begin
+            cdc_receive(sequence_data(8'h20, index));
+        end
         @(negedge dst_clk_i);
         cdc_m_ready = 1'b0;
 


### PR DESCRIPTION
Refs #13

Integrates thin production adapters around the pinned common_cells synchronous FIFO, Gray-pointer asynchronous FIFO, stream register, and spill register. Adds focused lint/simulation across legal FIFO depths 4, 8, and 16 without project-owned storage.

Owner verification:
- Verilator 5.048 common primitive tests passed for depths 4/8/16
- full ctest passed at JOBS=2
- both pytest suites passed
- 2x2 verify passed
- post-verification make clean left the worktree clean

Sandcastle produced the implementation/review commits; host timeout interrupted only the final publish step.