### PR TITLE
test(rtl): verify common primitive integration

### DIFF
--- a/rtl/common/test.sh
+++ b/rtl/common/test.sh
@@ -32,6 +32,7 @@ task_sources=(
     "$task_root/rtl/common/axi_async_fifo.sv"
     "$task_root/rtl/common/noc_reg_slice.sv"
     "$task_root/rtl/common/tests/tb_common_primitives.sv"
+    "$task_root/rtl/common/tests/tb_common_primitive_guards.sv"
 )
 
 task_verilator=(
@@ -54,6 +55,18 @@ case "$task_mode" in
                 --binary --Mdir "$task_obj_dir" -o common_primitives_tb \
                 "${task_sources[@]}"
             "$task_obj_dir/common_primitives_tb"
+        done
+        for task_case in 0 1 2; do
+            task_obj_dir="$task_tmp/obj_dir_invalid_$task_case"
+            "${task_verilator[@]}" \
+                --top-module tb_common_primitive_guards \
+                -GINVALID_CASE="$task_case" \
+                --binary --Mdir "$task_obj_dir" -o common_primitive_guards_tb \
+                "${task_sources[@]}"
+            if "$task_obj_dir/common_primitive_guards_tb" >/dev/null 2>&1; then
+                echo "adapter parameter guard $task_case did not fail" >&2
+                exit 1
+            fi
         done
         ;;
     *)

--- a/rtl/common/test.sh
+++ b/rtl/common/test.sh
@@ -41,6 +41,12 @@ task_verilator=(
     -I"$task_common_cells/include" --top-module tb_common_primitives
 )
 
+task_guard_messages=(
+    "NOC_FIFO_DEPTH must be 4, 8, or 16"
+    "AXI_FIFO_DEPTH must be 4, 8, or 16"
+    "REG_TYPE must be 0, 1, or 2"
+)
+
 case "$task_mode" in
     lint)
         "${task_verilator[@]}" --lint-only "${task_sources[@]}"
@@ -58,13 +64,19 @@ case "$task_mode" in
         done
         for task_case in 0 1 2; do
             task_obj_dir="$task_tmp/obj_dir_invalid_$task_case"
+            task_log="$task_tmp/guard_$task_case.log"
             "${task_verilator[@]}" \
                 --top-module tb_common_primitive_guards \
                 -GINVALID_CASE="$task_case" \
                 --binary --Mdir "$task_obj_dir" -o common_primitive_guards_tb \
                 "${task_sources[@]}"
-            if "$task_obj_dir/common_primitive_guards_tb" >/dev/null 2>&1; then
+            if "$task_obj_dir/common_primitive_guards_tb" >"$task_log" 2>&1; then
                 echo "adapter parameter guard $task_case did not fail" >&2
+                exit 1
+            fi
+            if ! grep -Fq "${task_guard_messages[$task_case]}" "$task_log"; then
+                cat "$task_log" >&2
+                echo "adapter parameter guard $task_case failed for an unexpected reason" >&2
                 exit 1
             fi
         done

--- a/rtl/common/tests/tb_common_primitive_guards.sv
+++ b/rtl/common/tests/tb_common_primitive_guards.sv
@@ -1,0 +1,71 @@
+`resetall
+`timescale 1ns / 1ps
+`default_nettype none
+
+module tb_common_primitive_guards #(
+    parameter int unsigned INVALID_CASE = 0
+);
+
+    logic clk_i = 1'b0;
+    logic rst_ni = 1'b0;
+    logic src_clk_i = 1'b0;
+    logic src_rst_ni = 1'b0;
+    logic dst_clk_i = 1'b0;
+    logic dst_rst_ni = 1'b0;
+    logic guard_s_ready;
+    logic guard_m_valid;
+    logic guard_data;
+
+    if (INVALID_CASE == 0) begin : gen_invalid_noc_fifo_depth
+        noc_sync_fifo #(
+            .NOC_FIFO_DEPTH ( 3 )
+        ) i_noc_sync_fifo (
+            .clk_i,
+            .rst_ni,
+            .s_valid_i ( 1'b0 ),
+            .s_ready_o ( guard_s_ready ),
+            .s_data_i  ( 1'b0 ),
+            .m_valid_o ( guard_m_valid ),
+            .m_ready_i ( 1'b0 ),
+            .m_data_o  ( guard_data )
+        );
+    end else if (INVALID_CASE == 1) begin : gen_invalid_axi_fifo_depth
+        axi_async_fifo #(
+            .AXI_FIFO_DEPTH ( 3 )
+        ) i_axi_async_fifo (
+            .src_clk_i,
+            .src_rst_ni,
+            .src_valid_i ( 1'b0 ),
+            .src_ready_o ( guard_s_ready ),
+            .src_data_i  ( 1'b0 ),
+            .dst_clk_i,
+            .dst_rst_ni,
+            .dst_valid_o ( guard_m_valid ),
+            .dst_ready_i ( 1'b0 ),
+            .dst_data_o  ( guard_data )
+        );
+    end else if (INVALID_CASE == 2) begin : gen_invalid_reg_type
+        noc_reg_slice #(
+            .REG_TYPE ( 3 )
+        ) i_noc_reg_slice (
+            .clk_i,
+            .rst_ni,
+            .s_valid_i ( 1'b0 ),
+            .s_ready_o ( guard_s_ready ),
+            .s_data_i  ( 1'b0 ),
+            .m_valid_o ( guard_m_valid ),
+            .m_ready_i ( 1'b0 ),
+            .m_data_o  ( guard_data )
+        );
+    end else begin : gen_invalid_test_case
+        initial $fatal(0, "Error: INVALID_CASE must select one adapter guard (instance %m)");
+    end
+
+    initial begin
+        #10ns;
+        $fatal(1, "Expected adapter parameter guard did not fail");
+    end
+
+endmodule
+
+`resetall

--- a/rtl/common/tests/tb_common_primitive_guards.sv
+++ b/rtl/common/tests/tb_common_primitive_guards.sv
@@ -63,7 +63,7 @@ module tb_common_primitive_guards #(
 
     initial begin
         #10ns;
-        $fatal(1, "Expected adapter parameter guard did not fail");
+        $finish;
     end
 
 endmodule

--- a/rtl/common/tests/tb_common_primitives.sv
+++ b/rtl/common/tests/tb_common_primitives.sv
@@ -226,6 +226,9 @@ module tb_common_primitives #(
                     stalled_data = cdc_m_data;
                 end
             end
+            @(posedge dst_clk_i);
+            assert (!cdc_m_valid)
+                else $fatal(1, "CDC FIFO produced an extra transaction %0h", cdc_m_data);
             @(negedge dst_clk_i);
             cdc_m_ready = 1'b0;
         end
@@ -352,6 +355,48 @@ module tb_common_primitives #(
         @(negedge clk_i);
         skid_m_ready = 1'b0;
         assert (!skid_m_valid) else $fatal(1, "Skid buffer did not drain");
+
+        // Load every stateful adapter so reset checks cannot pass from an already-empty state.
+        @(negedge clk_i);
+        sync_m_ready = 1'b0;
+        simple_m_ready = 1'b0;
+        skid_m_ready = 1'b0;
+        @(negedge dst_clk_i);
+        cdc_m_ready = 1'b0;
+
+        sync_send(8'ha0);
+        wait (sync_m_valid);
+        assert (sync_m_data == 8'ha0)
+            else $fatal(1, "Reset precondition lost the synchronous FIFO transaction");
+
+        cdc_send_stream(8'ha1, 1);
+        wait (cdc_m_valid);
+        assert (cdc_m_data == 8'ha1)
+            else $fatal(1, "Reset precondition lost the CDC FIFO transaction");
+
+        @(negedge clk_i);
+        simple_s_data = 8'ha2;
+        simple_s_valid = 1'b1;
+        do @(posedge clk_i); while (!simple_s_ready);
+        @(negedge clk_i);
+        simple_s_valid = 1'b0;
+        wait (simple_m_valid);
+        assert (simple_m_data == 8'ha2)
+            else $fatal(1, "Reset precondition lost the simple-register transaction");
+
+        @(negedge clk_i);
+        skid_s_data = 8'ha3;
+        skid_s_valid = 1'b1;
+        do @(posedge clk_i); while (!skid_s_ready);
+        @(negedge clk_i);
+        skid_s_valid = 1'b0;
+        wait (skid_m_valid);
+        assert (skid_m_data == 8'ha3)
+            else $fatal(1, "Reset precondition lost the skid-buffer transaction");
+
+        assert (sync_m_valid && cdc_m_valid && simple_m_valid && skid_m_valid)
+            else $fatal(1, "Reset precondition valid state is sync=%0b cdc=%0b simple=%0b skid=%0b",
+                        sync_m_valid, cdc_m_valid, simple_m_valid, skid_m_valid);
 
         // Reset asserts together, then each clock domain resumes independently.
         @(negedge clk_i);

--- a/rtl/common/tests/tb_common_primitives.sv
+++ b/rtl/common/tests/tb_common_primitives.sv
@@ -49,6 +49,9 @@ module tb_common_primitives #(
     logic       skid_m_ready;
     logic [7:0] skid_m_data;
 
+    int unsigned cdc_src_lfsr = 32'h1;
+    int unsigned cdc_dst_lfsr = 32'h2;
+
     noc_sync_fifo #(
         .T              ( logic [7:0] ),
         .NOC_FIFO_DEPTH ( NOC_FIFO_DEPTH )
@@ -137,6 +140,10 @@ module tb_common_primitives #(
         sequence_data = base + 8'(index);
     endfunction
 
+    function automatic int unsigned lfsr_next(input int unsigned state);
+        lfsr_next = state * 32'd1_664_525 + 32'd1_013_904_223;
+    endfunction
+
     task automatic sync_send(input logic [7:0] data);
         begin
             @(negedge clk_i);
@@ -148,24 +155,79 @@ module tb_common_primitives #(
         end
     endtask
 
-    task automatic cdc_send(input logic [7:0] data);
+    task automatic sync_fill_and_drain(input logic [7:0] base);
         begin
-            @(negedge src_clk_i);
-            cdc_s_data = data;
-            cdc_s_valid = 1'b1;
-            do @(posedge src_clk_i); while (!cdc_s_ready);
-            @(negedge src_clk_i);
-            cdc_s_valid = 1'b0;
+            for (int unsigned index = 0; index < NOC_FIFO_DEPTH; index++) begin
+                sync_send(sequence_data(base, index));
+            end
+            assert (!sync_s_ready) else $fatal(1, "Synchronous FIFO did not become full");
+            repeat (3) begin
+                assert (sync_m_valid && sync_m_data == base)
+                    else $fatal(1, "Synchronous FIFO changed its stalled head transaction");
+                @(posedge clk_i);
+                #1ps;
+            end
+            sync_m_ready = 1'b1;
+            for (int unsigned index = 0; index < NOC_FIFO_DEPTH; index++) begin
+                sync_receive(sequence_data(base, index));
+            end
+            @(negedge clk_i);
+            sync_m_ready = 1'b0;
+            assert (!sync_m_valid) else $fatal(1, "Synchronous FIFO did not drain");
         end
     endtask
 
-    task automatic cdc_receive(input logic [7:0] expected);
+    task automatic cdc_send_stream(
+        input logic [7:0] base,
+        input int unsigned count
+    );
         begin
-            wait (cdc_m_valid);
-            assert (cdc_m_data == expected)
-                else $fatal(1, "CDC FIFO expected %0h, got %0h", expected, cdc_m_data);
-            @(posedge dst_clk_i);
-            #1ps;
+            for (int unsigned index = 0; index < count; index++) begin
+                cdc_src_lfsr = lfsr_next(cdc_src_lfsr);
+                repeat (int'(cdc_src_lfsr[1:0])) @(negedge src_clk_i);
+                @(negedge src_clk_i);
+                cdc_s_data = sequence_data(base, index);
+                cdc_s_valid = 1'b1;
+                do @(posedge src_clk_i); while (!cdc_s_ready);
+                @(negedge src_clk_i);
+                cdc_s_valid = 1'b0;
+            end
+        end
+    endtask
+
+    task automatic cdc_receive_stream(
+        input logic [7:0] base,
+        input int unsigned count
+    );
+        int unsigned received;
+        logic        stalled;
+        logic [7:0]  stalled_data;
+        begin
+            received = 0;
+            stalled = 1'b0;
+            cdc_m_ready = 1'b0;
+            while (received < count) begin
+                @(negedge dst_clk_i);
+                cdc_dst_lfsr = lfsr_next(cdc_dst_lfsr);
+                cdc_m_ready = cdc_dst_lfsr[0];
+                @(posedge dst_clk_i);
+                if (stalled) begin
+                    assert (cdc_m_valid && cdc_m_data == stalled_data)
+                        else $fatal(1, "CDC FIFO changed its stalled head transaction");
+                end
+                if (cdc_m_valid && cdc_m_ready) begin
+                    assert (cdc_m_data == sequence_data(base, received))
+                        else $fatal(1, "CDC FIFO expected %0h, got %0h",
+                                    sequence_data(base, received), cdc_m_data);
+                    received++;
+                end
+                stalled = cdc_m_valid && !cdc_m_ready;
+                if (stalled) begin
+                    stalled_data = cdc_m_data;
+                end
+            end
+            @(negedge dst_clk_i);
+            cdc_m_ready = 1'b0;
         end
     endtask
 
@@ -209,42 +271,33 @@ module tb_common_primitives #(
         assert (!sync_m_valid && !cdc_m_valid && !simple_m_valid && !skid_m_valid)
             else $fatal(1, "Primitive output valid was not cleared by reset");
 
-        // The synchronous FIFO is non-fall-through and preserves every entry.
-        for (int unsigned index = 0; index < NOC_FIFO_DEPTH; index++) begin
-            sync_send(sequence_data(8'h10, index));
-        end
-        assert (!sync_s_ready) else $fatal(1, "Synchronous FIFO did not become full");
-        repeat (3) begin
-            assert (sync_m_valid && sync_m_data == 8'h10)
-                else $fatal(1, "Synchronous FIFO changed its stalled head transaction");
-            @(posedge clk_i);
-            #1ps;
-        end
+        // Two complete fill/drain passes exercise FIFO pointer wraparound.
+        sync_fill_and_drain(8'h10);
+        sync_fill_and_drain(8'h20);
+
+        // A partial FIFO accepts one push while retiring its current head.
+        sync_send(8'h30);
+        @(negedge clk_i);
+        sync_s_data = 8'h31;
+        sync_s_valid = 1'b1;
         sync_m_ready = 1'b1;
-        for (int unsigned index = 0; index < NOC_FIFO_DEPTH; index++) begin
-            sync_receive(sequence_data(8'h10, index));
-        end
+        @(posedge clk_i);
+        assert (sync_m_valid && sync_m_data == 8'h30)
+            else $fatal(1, "Synchronous FIFO did not retain the simultaneous-pop head");
+        @(negedge clk_i);
+        sync_s_valid = 1'b0;
+        assert (sync_m_valid && sync_m_data == 8'h31)
+            else $fatal(1, "Synchronous FIFO lost the simultaneous-push transaction");
+        @(posedge clk_i);
         @(negedge clk_i);
         sync_m_ready = 1'b0;
-        assert (!sync_m_valid) else $fatal(1, "Synchronous FIFO did not drain");
+        assert (!sync_m_valid) else $fatal(1, "Synchronous FIFO did not drain after simultaneous push/pop");
 
-        // The Gray-pointer FIFO crosses unrelated clocks without reordering.
-        for (int unsigned index = 0; index < AXI_FIFO_DEPTH; index++) begin
-            cdc_send(sequence_data(8'h20, index));
-        end
-        wait (cdc_m_valid);
-        repeat (3) begin
-            assert (cdc_m_valid && cdc_m_data == 8'h20)
-                else $fatal(1, "CDC FIFO changed its stalled head transaction");
-            @(posedge dst_clk_i);
-            #1ps;
-        end
-        cdc_m_ready = 1'b1;
-        for (int unsigned index = 0; index < AXI_FIFO_DEPTH; index++) begin
-            cdc_receive(sequence_data(8'h20, index));
-        end
-        @(negedge dst_clk_i);
-        cdc_m_ready = 1'b0;
+        // Unrelated clocks plus randomized stalls preserve every CDC transaction in order.
+        fork
+            cdc_send_stream(8'h40, 3 * AXI_FIFO_DEPTH);
+            cdc_receive_stream(8'h40, 3 * AXI_FIFO_DEPTH);
+        join
 
         // Bypass has no storage or added latency.
         bypass_m_ready = 1'b1;
@@ -287,8 +340,11 @@ module tb_common_primitives #(
         @(posedge clk_i);
         @(negedge clk_i);
         skid_s_valid = 1'b0;
-        assert (skid_m_valid && skid_m_data == 8'h50)
-            else $fatal(1, "Skid buffer did not retain its first transaction");
+        repeat (3) begin
+            assert (skid_m_valid && skid_m_data == 8'h50)
+                else $fatal(1, "Skid buffer did not retain its first transaction");
+            @(posedge clk_i);
+        end
         skid_m_ready = 1'b1;
         @(posedge clk_i);
         wait (skid_m_valid && skid_m_data == 8'h51);
@@ -296,6 +352,31 @@ module tb_common_primitives #(
         @(negedge clk_i);
         skid_m_ready = 1'b0;
         assert (!skid_m_valid) else $fatal(1, "Skid buffer did not drain");
+
+        // Reset asserts together, then each clock domain resumes independently.
+        @(negedge clk_i);
+        rst_ni = 1'b0;
+        src_rst_ni = 1'b0;
+        dst_rst_ni = 1'b0;
+        #1ps;
+        assert (!sync_m_valid && !cdc_m_valid && !simple_m_valid && !skid_m_valid)
+            else $fatal(1, "Primitive output valid was not cleared by coordinated reset assertion");
+        repeat (2) @(posedge clk_i);
+        #1ps;
+        rst_ni = 1'b1;
+        repeat (2) @(posedge src_clk_i);
+        #1ps;
+        src_rst_ni = 1'b1;
+        repeat (3) @(posedge dst_clk_i);
+        #1ps;
+        dst_rst_ni = 1'b1;
+        assert (!sync_m_valid && !cdc_m_valid && !simple_m_valid && !skid_m_valid)
+            else $fatal(1, "Primitive output valid was not cleared by independent reset release");
+
+        fork
+            cdc_send_stream(8'h80, 2 * AXI_FIFO_DEPTH);
+            cdc_receive_stream(8'h80, 2 * AXI_FIFO_DEPTH);
+        join
 
         $display("PASS: common primitive adapters");
         $finish;


### PR DESCRIPTION
Closes #14

- cover sync/async FIFO wraparound, backpressure, and reset behavior
- cover REG_TYPE 0/1/2 and FIFO depths 4/8/16
- verify illegal parameter guards

Owner verification: Verilator 5.048 common RTL tests; 668 C++ tests; 158 specgen tests; 89 sim/tools tests; 2x2 verify; post-clean.