### PR TITLE
build(agent): require Linux-native workspace

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,12 +48,10 @@ Linux only. The build used to carry a native-Windows path (MSYS2 mingw64) and
 it is gone: it doubled every toolchain behaviour, which is how a test file that
 compiled under one and not the other went unnoticed.
 
-On WSL, build and run directly from the `/mnt/*` checkout — there is no
-source copy. Only the build OUTPUT has to live on the native filesystem,
-which is what `BUILD_ROOT` is for. A mirror under `$HOME` is worse than
-none: `$BUILD_ROOT/cmodel` records the source directory CMake configured
-against, so a second copy leaves ctest compiling one tree while you edit
-the other. Per-host settings
+On WSL, clone, build, simulate, and run agents from the Linux-native filesystem,
+for example `$HOME/work/noc_project`. Do not use a `/mnt/*` checkout for Git
+worktrees or Docker bind mounts. The Windows checkout is not a build or agent
+workspace; synchronize changes through Git. Per-host settings
 (`BUILD_ROOT`, `PYTHON3`, `VERILATOR`, `CMAKE`) go in a gitignored
 `local.mk` at the repo root. Offline hosts: unpack pre-fetched
 `googletest-src/` and `yaml-cpp-src/` into `~/noc_offline_deps`; the
@@ -72,10 +70,8 @@ and nothing else. `make build` (or `make build-cmodel`) is needed only
 before `make test`.
 
 Artifacts land under `$(BUILD_ROOT)` (gitignored), which defaults to
-`build/` in the repo; `make clean` removes them. On WSL set
-`BUILD_ROOT := $(HOME)/noc_build` in `local.mk` — a build under `/mnt/`
-produces a Windows-COFF yaml-cpp that the Linux linker rejects. The CMake
-cache records the source directory it was configured against, and
+`build/` in the Linux-native repo; `make clean` removes them. The CMake cache
+records the source directory it was configured against, and
 `make build-cmodel` honours whatever the cache names, so after moving the
 checkout delete the cache rather than editing it, and confirm with
 `grep CMAKE_HOME_DIRECTORY $BUILD_ROOT/cmodel/CMakeCache.txt`.
@@ -88,6 +84,20 @@ make pytest                                # specgen + sim/tools suites, golden 
 make docker-pytest                         # same Python suites in the pinned Docker toolchain
 python3 specgen/tools/codegen.py --check   # committed generated code matches sources
 ~~~
+
+## Agent Runner
+
+Run the DE/DV team only through the checked launcher:
+
+~~~bash
+tools/ic-team.sh --preflight
+tools/ic-team.sh --dry-run
+tools/ic-team.sh
+~~~
+
+The launcher pins Node through `ic-design-team/.nvmrc`, checks Docker, GitHub
+and Codex authentication, rejects `/mnt/*`, requires clean Linux-native target
+and reference repositories, and supplies the reference mount paths.
 
 
 ## Simulate (cosim)

--- a/docs/known-limitations.md
+++ b/docs/known-limitations.md
@@ -104,15 +104,10 @@ generated fabric drives one packed vector from a port connection (bit 0) alongsi
 `always_comb` (bits 1-4), which Verilator tolerates and VCS may reject; and deleting only
 `noc_fabric_<topo>.sv` leaves the build failing on a missing file rather than regenerating it.
 
-The WSL host is unstable under load. Working practice: rsync to `~/noc_project`, one foreground
-session at a time, and an echo-marker retry around each invocation.
-
-Two hazards come with that mirror. The CMake cache under `$HOME/noc_build` records the mirror as
-its source directory, so a `make` invoked from `/mnt/e` fails on the source-directory mismatch
-rather than building the working tree, and a `cmake --build` aimed straight at the build
-directory silently compiles the mirror instead. A pass count is evidence only once the mirror has
-been re-synced. The unbounded `-j` that used to take the host down mid-build is fixed; see the
-compiler-error row above.
+The former `/mnt/e` checkout plus rsync mirror workflow is retired. The canonical WSL working
+copy is the Linux-native `$HOME/work/noc_project` clone, and Windows copies synchronize through
+Git. `tools/ic-team.sh` rejects `/mnt/*` before launching an agent. The unbounded `-j` that used
+to take the host down mid-build is fixed; see the compiler-error row above.
 
 A tile interconnect decodes addresses and nothing else, so it cannot tell a collective write from
 a unicast. A collective whose address names the issuing node's own region therefore looks local,

--- a/tools/ic-team.sh
+++ b/tools/ic-team.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)
+work_root=${IC_WORK_ROOT:-"$HOME/work"}
+team_root=${IC_TEAM_ROOT:-"$work_root/ic-design-team"}
+
+case "$repo_root" in
+  /mnt/*) echo "error: run agents from the Linux-native clone under $HOME/work" >&2; exit 1 ;;
+esac
+
+for path in "$team_root" "$work_root/references/FlooNoC" "$work_root/references/taxi"; do
+  [[ -d "$path/.git" ]] || { echo "error: missing Linux-native repo: $path" >&2; exit 1; }
+done
+
+export NVM_DIR="$HOME/.nvm"
+[[ -s "$NVM_DIR/nvm.sh" ]] || { echo "error: nvm is not installed" >&2; exit 1; }
+. "$NVM_DIR/nvm.sh"
+nvm use --silent "$(cat "$team_root/.nvmrc")"
+
+docker info >/dev/null
+docker image inspect ic-design-team:latest >/dev/null
+gh auth status >/dev/null
+[[ -r "$HOME/.codex/auth.json" ]] || { echo "error: missing Codex auth" >&2; exit 1; }
+
+for path in "$repo_root" "$team_root" "$work_root/references/FlooNoC" "$work_root/references/taxi"; do
+  [[ -z "$(git -C "$path" status --porcelain)" ]] || {
+    echo "error: dirty repository: $path" >&2
+    exit 1
+  }
+done
+
+echo "preflight: Node $(node --version), Docker ready, Linux-native repositories clean"
+[[ ${1:-} == "--preflight" ]] && exit 0
+
+export FLOONOC_REFERENCE="$work_root/references/FlooNoC"
+export TAXI_REFERENCE="$work_root/references/taxi"
+exec npm --prefix "$team_root" run team -- \
+  --repo "$repo_root" --config ic-team.config.mts "$@"


### PR DESCRIPTION
Adds the single DE/DV launcher and preflight, rejects /mnt workspaces, supplies Linux-native reference paths, and retires the rsync mirror guidance. Verified with launcher preflight and issue #43 dry-run.