### PR TITLE
chore(team): enable lead planning config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,6 +86,7 @@ __pycache__/
 
 # Local-only doc references (not version-controlled)
 /docs/probe_section_layout_draft.md
+/docs/image/draw.vsdx
 /docs/backlog.md
 
 # SDD scratch (ledger, briefs, reports, codex reviews) — not version-controlled

--- a/ic-team.config.mts
+++ b/ic-team.config.mts
@@ -5,6 +5,11 @@ export default {
   image: "ic-design-team:latest",
   baseBranch: "main",
   maxParallel: 1,
+  planning: {
+    enabled: true,
+    campaignLabel: "campaign:rtl-v1",
+    maxTasks: 8,
+  },
   references: [
     {
       name: "FlooNoC",


### PR DESCRIPTION
Enables the explicit Lead planning phase for campaign:rtl-v1 with an 8-task limit and ignores the local docs/image/draw.vsdx source. No RTL changes. Verification: target dry-run dispatch and git diff --check.