### PR TITLE
N0-01: add NMU top-level interface shell

### DIFF
--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -52,6 +52,23 @@ Goal: Run focused C++/SV/specgen checks, clean generated/build artifacts, and co
 Success Criteria: Allocation/reuse, exhaustion/backpressure, response restoration, legal/illegal parameter checks, drift gate, and clean target pass.
 Status: Complete
 
+### Issue #75: NMU top-level shell
+
+#### Stage 1: Interface contract and focused DV
+Goal: Confirm the frozen NMU production faces against the generated packages, wrapper, and specifications, then add a canonical elaboration check.
+Success Criteria: The check instantiates all AXI and NoC ports and proves the canonical generated widths.
+Status: Complete
+
+#### Stage 2: Shell implementation
+Goal: Add the interface-only `nmu` production shell with its legal-configuration guards.
+Success Criteria: The shell has no functional datapath, queue, or child instantiation.
+Status: Complete
+
+#### Stage 3: Verification and cleanup
+Goal: Run the focused compile check from a clean tree and remove generated artifacts.
+Success Criteria: Canonical elaboration passes and `make clean` leaves no build or generated files.
+Status: Complete
+
 ### Issue #21: NMU SAM decode and timing cuts
 
 #### Stage 1: Contract and focused DV

--- a/docs/nmu-spec.md
+++ b/docs/nmu-spec.md
@@ -366,7 +366,7 @@ All ports below are the current C++/DPI `nmu_wrap` ports (`ref_model/top/nmu_wra
 | rst_ni | 1 | Synchronous active-low reset. Given only once, at the beginning of simulation. |
 | ctx_i | 64 | Model instance handle returned by `cmodel_nmu_create`. Constant after creation. |
 | axi_req_i.awvalid | 1 | AW valid. Must stay high until awready is observed. |
-| axi_req_i.awid | 3 | Write transaction ID. Sampled only on the awvalid && awready cycle. |
+| axi_req_i.awid | AXI_ID_WIDTH (default 3) | Write transaction ID. Sampled only on the awvalid && awready cycle. |
 | axi_req_i.awaddr | 48 | Write address. Must hit a SAM entry (guarantee G1). |
 | axi_req_i.awlen | 8 | Burst length minus 1, 0 <= awlen <= 8'hFF (256 beats max). |
 | axi_req_i.awsize | 3 | Beats of 2^awsize bytes, awsize <= 3'h6 = 64 bytes. |
@@ -398,10 +398,10 @@ Every output is a registered signal: it changes only at posedge clk_i and reflec
 | axi_rsp_o.wready | 1 | Pre-asserted: high whenever accepted AWs still owe W beats and the W FIFO has space. Does not wait for wvalid. |
 | axi_rsp_o.arready | 1 | One-shot, same policy as awready, independent of the write side. |
 | axi_rsp_o.bvalid | 1 | B beat available. Held high until bready is observed (AXI4 IHI 0022 A3.2.1). |
-| axi_rsp_o.bid | 3 | B transaction ID. 0 when bvalid is low. |
+| axi_rsp_o.bid | AXI_ID_WIDTH (default 3) | B transaction ID. 0 when bvalid is low. |
 | axi_rsp_o.bresp | 2 | Write response, masked to 2 bits. 0 when bvalid is low. |
 | axi_rsp_o.rvalid | 1 | R beat available. Held high until rready is observed. |
-| axi_rsp_o.rid, rdata, rresp, rlast | 3, 512, 2, 1 | Read response fields. 0 when rvalid is low. |
+| axi_rsp_o.rid, rdata, rresp, rlast | AXI_ID_WIDTH (default 3), 512, 2, 1 | Read response fields. 0 when rvalid is low. |
 | tx_req_valid_o | 1 | REQ request flit on the wire. The model-facing wrapper holds `valid` and `tx_req_flit_o` until `tx_req_ready_i` is sampled high. At most one flit transfers per cycle. |
 | tx_req_flit_o | 136 | REQ request flit, format of Section 2.2. 0 when valid is low. |
 | rx_rsp_ready_o | 1 | RSP ingress ready. Tied true: the model's ingress queue is unbounded (`nmu_wrap.hpp`). |

--- a/ref_model/top/ni_wrap.sv
+++ b/ref_model/top/ni_wrap.sv
@@ -42,7 +42,7 @@
 // `include needed.
 
 module ni_wrap #(
-    parameter int unsigned ID_WIDTH       = ni_params_pkg::NOC_ID_WIDTH_DFLT,
+    parameter int unsigned ID_WIDTH       = ni_params_pkg::AXI_ID_WIDTH_DFLT,
     parameter int unsigned ADDR_WIDTH     = ni_params_pkg::AXI_ADDR_WIDTH_DFLT,
     parameter int unsigned DATA_WIDTH     = ni_params_pkg::AXI_DATA_WIDTH_DFLT,
     parameter int unsigned DAT_NUM_VC     = ni_params_pkg::NOC_DAT_NUM_VC_DFLT,

--- a/ref_model/top/nmu_wrap.sv
+++ b/ref_model/top/nmu_wrap.sv
@@ -39,7 +39,7 @@
 `define NMU_WRAP_SV
 
 module nmu_wrap #(
-    parameter int unsigned ID_WIDTH       = ni_params_pkg::NOC_ID_WIDTH_DFLT,
+    parameter int unsigned ID_WIDTH       = ni_params_pkg::AXI_ID_WIDTH_DFLT,
     parameter int unsigned ADDR_WIDTH     = ni_params_pkg::AXI_ADDR_WIDTH_DFLT,
     parameter int unsigned DATA_WIDTH     = ni_params_pkg::AXI_DATA_WIDTH_DFLT,
     parameter int unsigned DAT_NUM_VC     = ni_params_pkg::NOC_DAT_NUM_VC_DFLT,

--- a/ref_model/top/nsu_wrap.sv
+++ b/ref_model/top/nsu_wrap.sv
@@ -36,7 +36,7 @@
 `define NSU_WRAP_SV
 
 module nsu_wrap #(
-    parameter int unsigned ID_WIDTH       = ni_params_pkg::NOC_ID_WIDTH_DFLT,
+    parameter int unsigned ID_WIDTH       = ni_params_pkg::NSU_AXI_ID_WIDTH_DFLT,
     parameter int unsigned ADDR_WIDTH     = ni_params_pkg::AXI_ADDR_WIDTH_DFLT,
     parameter int unsigned DATA_WIDTH     = ni_params_pkg::AXI_DATA_WIDTH_DFLT,
     parameter int unsigned DAT_NUM_VC     = ni_params_pkg::NOC_DAT_NUM_VC_DFLT,

--- a/rtl/Bender.yml
+++ b/rtl/Bender.yml
@@ -12,3 +12,4 @@ sources:
   - common/ni_sam.sv
   - common/stream_register.sv
   - nmu/nmu_sam.sv
+  - nmu/nmu.sv

--- a/rtl/Bender.yml
+++ b/rtl/Bender.yml
@@ -8,7 +8,7 @@ dependencies:
     rev: 63b7c50d43e462b59506f69d341ff1e40202866d
 
 sources:
-  - common/taxi_axi_if.sv
+  - common/axi_if.sv
   - common/ni_child_types_pkg.sv
   - common/ni_sam.sv
   - common/stream_register.sv

--- a/rtl/Bender.yml
+++ b/rtl/Bender.yml
@@ -8,6 +8,7 @@ dependencies:
     rev: 63b7c50d43e462b59506f69d341ff1e40202866d
 
 sources:
+  - common/taxi_axi_if.sv
   - common/ni_child_types_pkg.sv
   - common/ni_sam.sv
   - common/stream_register.sv

--- a/rtl/README.md
+++ b/rtl/README.md
@@ -206,7 +206,9 @@ The 58-bit NMU `AWUSER` remains a sideband of the wrapper-facing AW channel and 
 50 bits are consumed by collective translation. No other AXI USER pin crosses the production
 top, so adding it to every channel record would widen CDC and queue storage without carrying
 information. The existing `axi_req_t` and `axi_rsp_t` aggregates remain the wrapper-facing types;
-children use the per-channel records above.
+children use the per-channel records above. Production RTL tops use the parameterized
+`taxi_axi_if` interface, so `AXI_ID_WIDTH`, `AXI_ADDR_WIDTH`, and `AXI_DATA_WIDTH` are
+elaboration-time port widths rather than fixed package typedef widths.
 
 `ni_flit_pkg` is the sole physical-flit type source. Each container is a packed struct with
 `header` in bits `[47:0]` and its network's widest payload immediately above it:

--- a/rtl/README.md
+++ b/rtl/README.md
@@ -207,7 +207,7 @@ The 58-bit NMU `AWUSER` remains a sideband of the wrapper-facing AW channel and 
 top, so adding it to every channel record would widen CDC and queue storage without carrying
 information. The existing `axi_req_t` and `axi_rsp_t` aggregates remain the wrapper-facing types;
 children use the per-channel records above. Production RTL tops use the parameterized
-`taxi_axi_if` interface, so `AXI_ID_WIDTH`, `AXI_ADDR_WIDTH`, and `AXI_DATA_WIDTH` are
+`axi_if` interface, so `AXI_ID_WIDTH`, `AXI_ADDR_WIDTH`, and `AXI_DATA_WIDTH` are
 elaboration-time port widths rather than fixed package typedef widths.
 
 `ni_flit_pkg` is the sole physical-flit type source. Each container is a packed struct with

--- a/rtl/README.md
+++ b/rtl/README.md
@@ -190,7 +190,8 @@ Generator tests use semantic assertions rather than committed golden RTL:
 
 `ni_signals_pkg` is the sole AXI payload-type source. Its channel records contain data only;
 `valid` and `ready` remain independent child ports. Packed field order below is LSB to MSB. The
-widths are the generated fixed-default widths already used by `axi_req_t` and `axi_rsp_t`:
+widths are the generated default widths used by `axi_req_t` and `axi_rsp_t`; AXI ID fields use
+`AXI_ID_WIDTH_DFLT`, while NoC-carried ID fields remain `NOC_ID_WIDTH_DFLT`:
 
 | Type | Width | Packed fields, LSB to MSB |
 |---|---:|---|

--- a/rtl/common/axi_if.sv
+++ b/rtl/common/axi_if.sv
@@ -8,7 +8,7 @@ Authors:
 
 */
 
-interface taxi_axi_if #(
+interface axi_if #(
     // Width of data bus in bits
     parameter DATA_W = 32,
     // Width of address bus in bits

--- a/rtl/common/taxi_axi_if.sv
+++ b/rtl/common/taxi_axi_if.sv
@@ -1,0 +1,261 @@
+// SPDX-License-Identifier: MIT
+/*
+
+Copyright (c) 2025 FPGA Ninja, LLC
+
+Authors:
+- Alex Forencich
+
+*/
+
+interface taxi_axi_if #(
+    // Width of data bus in bits
+    parameter DATA_W = 32,
+    // Width of address bus in bits
+    parameter ADDR_W = 32,
+    // Width of wstrb (width of data bus in words)
+    parameter STRB_W = (DATA_W/8),
+    // Width of ID signal
+    parameter ID_W = 8,
+    // Use awuser signal
+    parameter logic AWUSER_EN = 1'b0,
+    // Width of awuser signal
+    parameter AWUSER_W = 1,
+    // Use wuser signal
+    parameter logic WUSER_EN = 1'b0,
+    // Width of wuser signal
+    parameter WUSER_W = 1,
+    // Use buser signal
+    parameter logic BUSER_EN = 1'b0,
+    // Width of buser signal
+    parameter BUSER_W = 1,
+    // Use aruser signal
+    parameter logic ARUSER_EN = 1'b0,
+    // Width of aruser signal
+    parameter ARUSER_W = 1,
+    // Use ruser signal
+    parameter logic RUSER_EN = 1'b0,
+    // Width of ruser signal
+    parameter RUSER_W = 1,
+    // Maximum AXI burst length supported
+    parameter MAX_BURST_LEN = 256,
+    // Narrow bursts are supported
+    parameter logic NARROW_BURST_EN = 1'b1
+)
+();
+    // AW
+    logic [ID_W-1:0]      awid;
+    logic [ADDR_W-1:0]    awaddr;
+    logic [7:0]           awlen;
+    logic [2:0]           awsize;
+    logic [1:0]           awburst;
+    logic                 awlock;
+    logic [3:0]           awcache;
+    logic [2:0]           awprot;
+    logic [3:0]           awqos;
+    logic [3:0]           awregion;
+    logic [AWUSER_W-1:0]  awuser;
+    logic                 awvalid;
+    logic                 awready;
+    // W
+    logic [DATA_W-1:0]    wdata;
+    logic [STRB_W-1:0]    wstrb;
+    logic                 wlast;
+    logic [WUSER_W-1:0]   wuser;
+    logic                 wvalid;
+    logic                 wready;
+    // B
+    logic [ID_W-1:0]      bid;
+    logic [1:0]           bresp;
+    logic [BUSER_W-1:0]   buser;
+    logic                 bvalid;
+    logic                 bready;
+    // AR
+    logic [ID_W-1:0]      arid;
+    logic [ADDR_W-1:0]    araddr;
+    logic [7:0]           arlen;
+    logic [2:0]           arsize;
+    logic [1:0]           arburst;
+    logic                 arlock;
+    logic [3:0]           arcache;
+    logic [2:0]           arprot;
+    logic [3:0]           arqos;
+    logic [3:0]           arregion;
+    logic [ARUSER_W-1:0]  aruser;
+    logic                 arvalid;
+    logic                 arready;
+    // R
+    logic [ID_W-1:0]      rid;
+    logic [DATA_W-1:0]    rdata;
+    logic [1:0]           rresp;
+    logic                 rlast;
+    logic [RUSER_W-1:0]   ruser;
+    logic                 rvalid;
+    logic                 rready;
+
+    modport wr_mst (
+        // AW
+        output awid,
+        output awaddr,
+        output awlen,
+        output awsize,
+        output awburst,
+        output awlock,
+        output awcache,
+        output awprot,
+        output awqos,
+        output awregion,
+        output awuser,
+        output awvalid,
+        input  awready,
+        // W
+        output wdata,
+        output wstrb,
+        output wlast,
+        output wuser,
+        output wvalid,
+        input  wready,
+        // B
+        input  bid,
+        input  bresp,
+        input  buser,
+        input  bvalid,
+        output bready
+    );
+
+    modport rd_mst (
+        // AR
+        output arid,
+        output araddr,
+        output arlen,
+        output arsize,
+        output arburst,
+        output arlock,
+        output arcache,
+        output arprot,
+        output arqos,
+        output arregion,
+        output aruser,
+        output arvalid,
+        input  arready,
+        // R
+        input  rid,
+        input  rdata,
+        input  rresp,
+        input  rlast,
+        input  ruser,
+        input  rvalid,
+        output rready
+    );
+
+    modport wr_slv (
+        // AW
+        input  awid,
+        input  awaddr,
+        input  awlen,
+        input  awsize,
+        input  awburst,
+        input  awlock,
+        input  awcache,
+        input  awprot,
+        input  awqos,
+        input  awregion,
+        input  awuser,
+        input  awvalid,
+        output awready,
+        // W
+        input  wdata,
+        input  wstrb,
+        input  wlast,
+        input  wuser,
+        input  wvalid,
+        output wready,
+        // B
+        output bid,
+        output bresp,
+        output buser,
+        output bvalid,
+        input  bready
+    );
+
+    modport rd_slv (
+        // AR
+        input  arid,
+        input  araddr,
+        input  arlen,
+        input  arsize,
+        input  arburst,
+        input  arlock,
+        input  arcache,
+        input  arprot,
+        input  arqos,
+        input  arregion,
+        input  aruser,
+        input  arvalid,
+        output arready,
+        // R
+        output rid,
+        output rdata,
+        output rresp,
+        output rlast,
+        output ruser,
+        output rvalid,
+        input  rready
+    );
+
+    modport wr_mon (
+        // AW
+        input  awid,
+        input  awaddr,
+        input  awlen,
+        input  awsize,
+        input  awburst,
+        input  awlock,
+        input  awcache,
+        input  awprot,
+        input  awqos,
+        input  awregion,
+        input  awuser,
+        input  awvalid,
+        input  awready,
+        // W
+        input  wdata,
+        input  wstrb,
+        input  wlast,
+        input  wuser,
+        input  wvalid,
+        input  wready,
+        // B
+        input  bid,
+        input  bresp,
+        input  buser,
+        input  bvalid,
+        input  bready
+    );
+
+    modport rd_mon (
+        // AR
+        input  arid,
+        input  araddr,
+        input  arlen,
+        input  arsize,
+        input  arburst,
+        input  arlock,
+        input  arcache,
+        input  arprot,
+        input  arqos,
+        input  arregion,
+        input  aruser,
+        input  arvalid,
+        input  arready,
+        // R
+        input  rid,
+        input  rdata,
+        input  rresp,
+        input  rlast,
+        input  ruser,
+        input  rvalid,
+        input  rready
+    );
+
+endinterface

--- a/rtl/nmu/nmu.sv
+++ b/rtl/nmu/nmu.sv
@@ -34,9 +34,8 @@ module nmu #(
     input  wire logic                                                   noc_clk,
     input  wire logic                                                   noc_rst_n,
 
-    input  wire ni_signals_pkg::axi_req_t                              axi_req_i,
-    input  wire logic [AXI_AWUSER_WIDTH-1:0]                           awuser_i,
-    output wire ni_signals_pkg::axi_rsp_t                              axi_rsp_o,
+    taxi_axi_if.wr_slv                                                  axi_wr_i,
+    taxi_axi_if.rd_slv                                                  axi_rd_i,
 
     output wire logic                                                   tx_req_valid_o,
     output wire logic [ni_params_pkg::NOC_REQ_FLIT_WIDTH_DFLT-1:0]    tx_req_flit_o,

--- a/rtl/nmu/nmu.sv
+++ b/rtl/nmu/nmu.sv
@@ -1,0 +1,138 @@
+// SPDX-License-Identifier: Apache-2.0
+
+`resetall
+`timescale 1ns / 1ps
+`default_nettype none
+
+// Network Master Unit production top-level interface and parameter contract.
+module nmu #(
+    // External AXI interface configuration.
+    parameter int unsigned AXI_ID_WIDTH = ni_params_pkg::AXI_ID_WIDTH_DFLT,
+    parameter int unsigned NOC_ID_WIDTH = ni_params_pkg::NOC_ID_WIDTH_DFLT,
+    parameter int unsigned AXI_ADDR_WIDTH = ni_params_pkg::AXI_ADDR_WIDTH_DFLT,
+    parameter int unsigned AXI_DATA_WIDTH = ni_params_pkg::AXI_DATA_WIDTH_DFLT,
+    parameter int unsigned AXI_AWUSER_WIDTH = ni_params_pkg::AXI_AWUSER_WIDTH_DFLT,
+    parameter int unsigned AXI_FIFO_DEPTH = ni_params_pkg::AXI_FIFO_DEPTH_DFLT,
+    // NoC interface configuration.
+    parameter int unsigned NOC_DAT_NUM_VC = ni_params_pkg::NOC_DAT_NUM_VC_DFLT,
+    parameter int unsigned NOC_DAT_VC_MODE = ni_params_pkg::NOC_DAT_VC_MODE_DFLT,
+    parameter int unsigned NOC_FIFO_DEPTH = ni_params_pkg::NOC_FIFO_DEPTH_DFLT,
+    parameter int unsigned NOC_ROUTER_VC_DEPTH = ni_params_pkg::NOC_ROUTER_VC_DEPTH_DFLT,
+    // NMU transaction ordering configuration.
+    parameter int unsigned NMU_ROB_B_DEPTH = ni_params_pkg::NMU_ROB_B_DEPTH_DFLT,
+    parameter int unsigned NMU_ROB_R_DEPTH = ni_params_pkg::NMU_ROB_R_DEPTH_DFLT,
+    parameter bit READ_ROB_ENABLED = bit'(ni_params_pkg::NMU_READ_ROB_ENABLED_DFLT),
+    parameter int unsigned NMU_MAX_TXNS_PER_ID = ni_params_pkg::NMU_MAX_TXNS_PER_ID_DFLT,
+    parameter int unsigned AW_SAM_REG_TYPE = 0,
+    parameter int unsigned AR_SAM_REG_TYPE = 0,
+    // Local network-interface identity.
+    parameter logic [ni_flit_pkg::SRC_ID_WIDTH-1:0] SRC_ID = '0,
+    parameter logic [ni_flit_pkg::SRC_PORT_ID_WIDTH-1:0] SRC_PORT_ID = '0
+) (
+    input  wire logic                                                   ACLK,
+    input  wire logic                                                   ARESETn,
+    input  wire logic                                                   noc_clk,
+    input  wire logic                                                   noc_rst_n,
+
+    input  wire ni_signals_pkg::axi_req_t                              axi_req_i,
+    input  wire logic [AXI_AWUSER_WIDTH-1:0]                           awuser_i,
+    output wire ni_signals_pkg::axi_rsp_t                              axi_rsp_o,
+
+    output wire logic                                                   tx_req_valid_o,
+    output wire logic [ni_params_pkg::NOC_REQ_FLIT_WIDTH_DFLT-1:0]    tx_req_flit_o,
+    input  wire logic                                                   tx_req_ready_i,
+
+    input  wire logic                                                   rx_rsp_valid_i,
+    input  wire logic [ni_params_pkg::NOC_RSP_FLIT_WIDTH_DFLT-1:0]    rx_rsp_flit_i,
+    output wire logic                                                   rx_rsp_ready_o,
+
+    output wire logic                                                   tx_dat_valid_o,
+    output wire logic [ni_params_pkg::NOC_DAT_FLIT_WIDTH_DFLT-1:0]    tx_dat_flit_o,
+    input  wire logic [NOC_DAT_NUM_VC-1:0]                             tx_dat_crdvalid_i,
+    input  wire logic                                                   rx_dat_valid_i,
+    input  wire logic [ni_params_pkg::NOC_DAT_FLIT_WIDTH_DFLT-1:0]    rx_dat_flit_i,
+    output wire logic                                                   rx_dat_ready_o
+);
+
+    localparam int unsigned REQ_FLIT_W = $bits(ni_flit_pkg::req_flit_t);
+    localparam int unsigned RSP_FLIT_W = $bits(ni_flit_pkg::rsp_flit_t);
+    localparam int unsigned DAT_FLIT_W = $bits(ni_flit_pkg::dat_flit_t);
+
+    if (AXI_ID_WIDTH < 1 || AXI_ID_WIDTH > 8) begin : gen_invalid_axi_id_width
+        initial $fatal(0, "Error: AXI_ID_WIDTH must be in [1, 8] (instance %m)");
+    end
+
+    if (NOC_ID_WIDTH != ni_params_pkg::NOC_ID_WIDTH_DFLT) begin : gen_invalid_noc_id_width
+        initial $fatal(0, "Error: NOC_ID_WIDTH must match the generated fixed width (instance %m)");
+    end
+
+    if (AXI_ADDR_WIDTH < 1 || AXI_ADDR_WIDTH > 64) begin : gen_invalid_axi_addr_width
+        initial $fatal(0, "Error: AXI_ADDR_WIDTH must be in [1, 64] (instance %m)");
+    end
+
+    if (AXI_DATA_WIDTH != 32 && AXI_DATA_WIDTH != 64 && AXI_DATA_WIDTH != 128 &&
+            AXI_DATA_WIDTH != 256 && AXI_DATA_WIDTH != 512 && AXI_DATA_WIDTH != 1024) begin : gen_invalid_axi_data_width
+        initial $fatal(0, "Error: AXI_DATA_WIDTH must be 32, 64, 128, 256, 512, or 1024 (instance %m)");
+    end
+
+    if (AXI_AWUSER_WIDTH < 10 || AXI_AWUSER_WIDTH > 64) begin : gen_invalid_axi_awuser_width
+        initial $fatal(0, "Error: AXI_AWUSER_WIDTH must be in [10, 64] (instance %m)");
+    end
+
+    if (NOC_DAT_NUM_VC < 1 || NOC_DAT_NUM_VC > 8) begin : gen_invalid_dat_num_vc
+        initial $fatal(0, "Error: NOC_DAT_NUM_VC must be in [1, 8] (instance %m)");
+    end
+
+    if (NOC_DAT_VC_MODE != ni_params_pkg::NOC_DAT_VC_MODE_SHARED &&
+            NOC_DAT_VC_MODE != ni_params_pkg::NOC_DAT_VC_MODE_READ_WRITE_SPLIT) begin : gen_invalid_dat_vc_mode
+        initial $fatal(0, "Error: NOC_DAT_VC_MODE is invalid (instance %m)");
+    end
+
+    if (NOC_DAT_VC_MODE == ni_params_pkg::NOC_DAT_VC_MODE_READ_WRITE_SPLIT &&
+            !(NOC_DAT_NUM_VC == 2 || NOC_DAT_NUM_VC == 4 ||
+                NOC_DAT_NUM_VC == 6 || NOC_DAT_NUM_VC == 8)) begin : gen_invalid_dat_vc_split
+        initial $fatal(0, "Error: READ_WRITE_SPLIT requires NOC_DAT_NUM_VC of 2, 4, 6, or 8 (instance %m)");
+    end
+
+    if (AXI_FIFO_DEPTH < 2 || (AXI_FIFO_DEPTH & (AXI_FIFO_DEPTH - 1)) != 0) begin : gen_invalid_axi_fifo_depth
+        initial $fatal(0, "Error: AXI_FIFO_DEPTH must be a power of two and at least 2 (instance %m)");
+    end
+
+    if (NOC_FIFO_DEPTH == 0 || (NOC_FIFO_DEPTH & (NOC_FIFO_DEPTH - 1)) != 0) begin : gen_invalid_noc_fifo_depth
+        initial $fatal(0, "Error: NOC_FIFO_DEPTH must be a positive power of two (instance %m)");
+    end
+
+    if (NOC_ROUTER_VC_DEPTH < 2 ||
+            (NOC_ROUTER_VC_DEPTH & (NOC_ROUTER_VC_DEPTH - 1)) != 0) begin : gen_invalid_router_vc_depth
+        initial $fatal(0, "Error: NOC_ROUTER_VC_DEPTH must be a power of two and at least 2 (instance %m)");
+    end
+
+    if (NMU_ROB_B_DEPTH < 1 || NMU_ROB_B_DEPTH > 256) begin : gen_invalid_rob_b_depth
+        initial $fatal(0, "Error: NMU_ROB_B_DEPTH must be in [1, 256] (instance %m)");
+    end
+
+    if (NMU_ROB_R_DEPTH < 1 || NMU_ROB_R_DEPTH > 256) begin : gen_invalid_rob_r_depth
+        initial $fatal(0, "Error: NMU_ROB_R_DEPTH must be in [1, 256] (instance %m)");
+    end
+
+    if (NMU_MAX_TXNS_PER_ID < 1 || NMU_MAX_TXNS_PER_ID > 256) begin : gen_invalid_max_txns_per_id
+        initial $fatal(0, "Error: NMU_MAX_TXNS_PER_ID must be in [1, 256] (instance %m)");
+    end
+
+    if (AW_SAM_REG_TYPE > 2) begin : gen_invalid_aw_sam_reg_type
+        initial $fatal(0, "Error: AW_SAM_REG_TYPE must be 0, 1, or 2 (instance %m)");
+    end
+
+    if (AR_SAM_REG_TYPE > 2) begin : gen_invalid_ar_sam_reg_type
+        initial $fatal(0, "Error: AR_SAM_REG_TYPE must be 0, 1, or 2 (instance %m)");
+    end
+
+    if (REQ_FLIT_W != ni_params_pkg::NOC_REQ_FLIT_WIDTH_DFLT ||
+            RSP_FLIT_W != ni_params_pkg::NOC_RSP_FLIT_WIDTH_DFLT ||
+            DAT_FLIT_W != ni_params_pkg::NOC_DAT_FLIT_WIDTH_DFLT) begin : gen_invalid_flit_width
+        initial $fatal(0, "Error: generated flit widths do not match the parameter package (instance %m)");
+    end
+
+endmodule
+
+`resetall

--- a/rtl/nmu/nmu.sv
+++ b/rtl/nmu/nmu.sv
@@ -34,8 +34,8 @@ module nmu #(
     input  wire logic                                                   noc_clk,
     input  wire logic                                                   noc_rst_n,
 
-    taxi_axi_if.wr_slv                                                  axi_wr_i,
-    taxi_axi_if.rd_slv                                                  axi_rd_i,
+    axi_if.wr_slv                                                  axi_wr_i,
+    axi_if.rd_slv                                                  axi_rd_i,
 
     output wire logic                                                   tx_req_valid_o,
     output wire logic [ni_params_pkg::NOC_REQ_FLIT_WIDTH_DFLT-1:0]    tx_req_flit_o,

--- a/rtl/nmu/test_nmu.sh
+++ b/rtl/nmu/test_nmu.sh
@@ -10,7 +10,7 @@ task_sources=(
     "$task_root/specgen/generated/sv/ni_params_pkg.sv"
     "$task_root/specgen/generated/sv/ni_signals_pkg.sv"
     "$task_root/specgen/generated/sv/ni_flit_pkg.sv"
-    "$task_root/rtl/common/taxi_axi_if.sv"
+    "$task_root/rtl/common/axi_if.sv"
     "$task_root/rtl/nmu/nmu.sv"
     "$task_root/rtl/nmu/tests/tb_nmu_elaborate.sv"
 )

--- a/rtl/nmu/test_nmu.sh
+++ b/rtl/nmu/test_nmu.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+ulimit -c 0
+
+task_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
+task_tmp=$(mktemp -d "${TMPDIR:-/tmp}/noc-nmu-shell-XXXXXX")
+trap 'rm -rf "$task_tmp"' EXIT
+
+task_sources=(
+    "$task_root/specgen/generated/sv/ni_params_pkg.sv"
+    "$task_root/specgen/generated/sv/ni_signals_pkg.sv"
+    "$task_root/specgen/generated/sv/ni_flit_pkg.sv"
+    "$task_root/rtl/nmu/nmu.sv"
+    "$task_root/rtl/nmu/tests/tb_nmu_elaborate.sv"
+)
+
+task_verilator=(
+    verilator --timing --assert -Wall -Wno-fatal -Wno-DECLFILENAME -Wno-TIMESCALEMOD
+    --top-module tb_nmu_elaborate
+)
+
+"${task_verilator[@]}" --lint-only "${task_sources[@]}"
+"${task_verilator[@]}" --binary --Mdir "$task_tmp/obj_dir" -o nmu_elaborate_tb "${task_sources[@]}"
+"$task_tmp/obj_dir/nmu_elaborate_tb"

--- a/rtl/nmu/test_nmu.sh
+++ b/rtl/nmu/test_nmu.sh
@@ -10,6 +10,7 @@ task_sources=(
     "$task_root/specgen/generated/sv/ni_params_pkg.sv"
     "$task_root/specgen/generated/sv/ni_signals_pkg.sv"
     "$task_root/specgen/generated/sv/ni_flit_pkg.sv"
+    "$task_root/rtl/common/taxi_axi_if.sv"
     "$task_root/rtl/nmu/nmu.sv"
     "$task_root/rtl/nmu/tests/tb_nmu_elaborate.sv"
 )

--- a/rtl/nmu/tests/tb_nmu_elaborate.sv
+++ b/rtl/nmu/tests/tb_nmu_elaborate.sv
@@ -7,9 +7,13 @@ module tb_nmu_elaborate;
     logic noc_clk;
     logic noc_rst_n;
 
-    ni_signals_pkg::axi_req_t axi_req_i;
-    logic [ni_params_pkg::AXI_AWUSER_WIDTH_DFLT-1:0] awuser_i;
-    ni_signals_pkg::axi_rsp_t axi_rsp_o;
+    taxi_axi_if #(
+        .DATA_W(ni_params_pkg::AXI_DATA_WIDTH_DFLT),
+        .ADDR_W(ni_params_pkg::AXI_ADDR_WIDTH_DFLT),
+        .ID_W(8),
+        .AWUSER_EN(1'b1),
+        .AWUSER_W(ni_params_pkg::AXI_AWUSER_WIDTH_DFLT)
+    ) axi_if();
 
     logic tx_req_valid_o;
     logic [ni_params_pkg::NOC_REQ_FLIT_WIDTH_DFLT-1:0] tx_req_flit_o;
@@ -26,14 +30,15 @@ module tb_nmu_elaborate;
     logic [ni_params_pkg::NOC_DAT_FLIT_WIDTH_DFLT-1:0] rx_dat_flit_i;
     logic rx_dat_ready_o;
 
-    nmu dut (
+    nmu #(
+        .AXI_ID_WIDTH(8)
+    ) dut (
         .ACLK               ( ACLK               ),
         .ARESETn            ( ARESETn            ),
         .noc_clk            ( noc_clk            ),
         .noc_rst_n          ( noc_rst_n          ),
-        .axi_req_i          ( axi_req_i          ),
-        .awuser_i           ( awuser_i           ),
-        .axi_rsp_o          ( axi_rsp_o          ),
+        .axi_wr_i           ( axi_if.wr_slv      ),
+        .axi_rd_i           ( axi_if.rd_slv      ),
         .tx_req_valid_o     ( tx_req_valid_o     ),
         .tx_req_flit_o      ( tx_req_flit_o      ),
         .tx_req_ready_i     ( tx_req_ready_i     ),
@@ -49,13 +54,13 @@ module tb_nmu_elaborate;
     );
 
     initial begin
-        assert ($bits(axi_req_i.awid) == ni_params_pkg::AXI_ID_WIDTH_DFLT)
+        assert ($bits(axi_if.awid) == 8)
             else $fatal(1, "AXI request ID width mismatch");
-        assert ($bits(axi_req_i.awaddr) == ni_params_pkg::AXI_ADDR_WIDTH_DFLT)
+        assert ($bits(axi_if.awaddr) == ni_params_pkg::AXI_ADDR_WIDTH_DFLT)
             else $fatal(1, "AXI request address width mismatch");
-        assert ($bits(axi_req_i.wdata) == ni_params_pkg::AXI_DATA_WIDTH_DFLT)
+        assert ($bits(axi_if.wdata) == ni_params_pkg::AXI_DATA_WIDTH_DFLT)
             else $fatal(1, "AXI request data width mismatch");
-        assert ($bits(awuser_i) == ni_params_pkg::AXI_AWUSER_WIDTH_DFLT)
+        assert ($bits(axi_if.awuser) == ni_params_pkg::AXI_AWUSER_WIDTH_DFLT)
             else $fatal(1, "AWUSER width mismatch");
         assert ($bits(tx_req_flit_o) == ni_params_pkg::NOC_REQ_FLIT_WIDTH_DFLT)
             else $fatal(1, "REQ flit width mismatch");

--- a/rtl/nmu/tests/tb_nmu_elaborate.sv
+++ b/rtl/nmu/tests/tb_nmu_elaborate.sv
@@ -49,7 +49,7 @@ module tb_nmu_elaborate;
     );
 
     initial begin
-        assert ($bits(axi_req_i.awid) == ni_params_pkg::NOC_ID_WIDTH_DFLT)
+        assert ($bits(axi_req_i.awid) == ni_params_pkg::AXI_ID_WIDTH_DFLT)
             else $fatal(1, "AXI request ID width mismatch");
         assert ($bits(axi_req_i.awaddr) == ni_params_pkg::AXI_ADDR_WIDTH_DFLT)
             else $fatal(1, "AXI request address width mismatch");

--- a/rtl/nmu/tests/tb_nmu_elaborate.sv
+++ b/rtl/nmu/tests/tb_nmu_elaborate.sv
@@ -1,0 +1,71 @@
+`timescale 1ns / 1ps
+
+module tb_nmu_elaborate;
+
+    logic ACLK;
+    logic ARESETn;
+    logic noc_clk;
+    logic noc_rst_n;
+
+    ni_signals_pkg::axi_req_t axi_req_i;
+    logic [ni_params_pkg::AXI_AWUSER_WIDTH_DFLT-1:0] awuser_i;
+    ni_signals_pkg::axi_rsp_t axi_rsp_o;
+
+    logic tx_req_valid_o;
+    logic [ni_params_pkg::NOC_REQ_FLIT_WIDTH_DFLT-1:0] tx_req_flit_o;
+    logic tx_req_ready_i;
+
+    logic rx_rsp_valid_i;
+    logic [ni_params_pkg::NOC_RSP_FLIT_WIDTH_DFLT-1:0] rx_rsp_flit_i;
+    logic rx_rsp_ready_o;
+
+    logic tx_dat_valid_o;
+    logic [ni_params_pkg::NOC_DAT_FLIT_WIDTH_DFLT-1:0] tx_dat_flit_o;
+    logic [ni_params_pkg::NOC_DAT_NUM_VC_DFLT-1:0] tx_dat_crdvalid_i;
+    logic rx_dat_valid_i;
+    logic [ni_params_pkg::NOC_DAT_FLIT_WIDTH_DFLT-1:0] rx_dat_flit_i;
+    logic rx_dat_ready_o;
+
+    nmu dut (
+        .ACLK               ( ACLK               ),
+        .ARESETn            ( ARESETn            ),
+        .noc_clk            ( noc_clk            ),
+        .noc_rst_n          ( noc_rst_n          ),
+        .axi_req_i          ( axi_req_i          ),
+        .awuser_i           ( awuser_i           ),
+        .axi_rsp_o          ( axi_rsp_o          ),
+        .tx_req_valid_o     ( tx_req_valid_o     ),
+        .tx_req_flit_o      ( tx_req_flit_o      ),
+        .tx_req_ready_i     ( tx_req_ready_i     ),
+        .rx_rsp_valid_i     ( rx_rsp_valid_i     ),
+        .rx_rsp_flit_i      ( rx_rsp_flit_i      ),
+        .rx_rsp_ready_o     ( rx_rsp_ready_o     ),
+        .tx_dat_valid_o     ( tx_dat_valid_o     ),
+        .tx_dat_flit_o      ( tx_dat_flit_o      ),
+        .tx_dat_crdvalid_i  ( tx_dat_crdvalid_i  ),
+        .rx_dat_valid_i     ( rx_dat_valid_i     ),
+        .rx_dat_flit_i      ( rx_dat_flit_i      ),
+        .rx_dat_ready_o     ( rx_dat_ready_o     )
+    );
+
+    initial begin
+        assert ($bits(axi_req_i.awid) == ni_params_pkg::NOC_ID_WIDTH_DFLT)
+            else $fatal(1, "AXI request ID width mismatch");
+        assert ($bits(axi_req_i.awaddr) == ni_params_pkg::AXI_ADDR_WIDTH_DFLT)
+            else $fatal(1, "AXI request address width mismatch");
+        assert ($bits(axi_req_i.wdata) == ni_params_pkg::AXI_DATA_WIDTH_DFLT)
+            else $fatal(1, "AXI request data width mismatch");
+        assert ($bits(awuser_i) == ni_params_pkg::AXI_AWUSER_WIDTH_DFLT)
+            else $fatal(1, "AWUSER width mismatch");
+        assert ($bits(tx_req_flit_o) == ni_params_pkg::NOC_REQ_FLIT_WIDTH_DFLT)
+            else $fatal(1, "REQ flit width mismatch");
+        assert ($bits(rx_rsp_flit_i) == ni_params_pkg::NOC_RSP_FLIT_WIDTH_DFLT)
+            else $fatal(1, "RSP flit width mismatch");
+        assert ($bits(tx_dat_flit_o) == ni_params_pkg::NOC_DAT_FLIT_WIDTH_DFLT)
+            else $fatal(1, "DAT flit width mismatch");
+        assert ($bits(tx_dat_crdvalid_i) == ni_params_pkg::NOC_DAT_NUM_VC_DFLT)
+            else $fatal(1, "DAT credit width mismatch");
+        $finish;
+    end
+
+endmodule

--- a/rtl/nmu/tests/tb_nmu_elaborate.sv
+++ b/rtl/nmu/tests/tb_nmu_elaborate.sv
@@ -7,7 +7,7 @@ module tb_nmu_elaborate;
     logic noc_clk;
     logic noc_rst_n;
 
-    taxi_axi_if #(
+    axi_if #(
         .DATA_W(ni_params_pkg::AXI_DATA_WIDTH_DFLT),
         .ADDR_W(ni_params_pkg::AXI_ADDR_WIDTH_DFLT),
         .ID_W(8),

--- a/specgen/generated/sv/ni_signals_pkg.sv
+++ b/specgen/generated/sv/ni_signals_pkg.sv
@@ -75,7 +75,7 @@ package ni_signals_pkg;
     logic [2:0]                                    awsize;
     logic [7:0]                                    awlen;
     logic [ni_params_pkg::AXI_ADDR_WIDTH_DFLT-1:0] awaddr;
-    logic [ni_params_pkg::NOC_ID_WIDTH_DFLT-1:0]   awid;
+    logic [ni_params_pkg::AXI_ID_WIDTH_DFLT-1:0]   awid;
   } axi_aw_t;
   typedef struct packed {
     logic [ni_params_pkg::AXI_DATA_WIDTH_DFLT-1:0]   wdata;
@@ -84,7 +84,7 @@ package ni_signals_pkg;
   } axi_w_t;
   typedef struct packed {
     logic [1:0]                                  bresp;
-    logic [ni_params_pkg::NOC_ID_WIDTH_DFLT-1:0] bid;
+    logic [ni_params_pkg::AXI_ID_WIDTH_DFLT-1:0] bid;
   } axi_b_t;
   typedef struct packed {
     logic [3:0]                                    arqos;
@@ -96,18 +96,18 @@ package ni_signals_pkg;
     logic [2:0]                                    arsize;
     logic [7:0]                                    arlen;
     logic [ni_params_pkg::AXI_ADDR_WIDTH_DFLT-1:0] araddr;
-    logic [ni_params_pkg::NOC_ID_WIDTH_DFLT-1:0]   arid;
+    logic [ni_params_pkg::AXI_ID_WIDTH_DFLT-1:0]   arid;
   } axi_ar_t;
   typedef struct packed {
     logic [ni_params_pkg::AXI_DATA_WIDTH_DFLT-1:0] rdata;
     logic [1:0]                                    rresp;
-    logic [ni_params_pkg::NOC_ID_WIDTH_DFLT-1:0]   rid;
+    logic [ni_params_pkg::AXI_ID_WIDTH_DFLT-1:0]   rid;
     logic                                          rlast;
   } axi_r_t;
 
   // AXI wrap-port aggregates (widths fixed-default).
   typedef struct packed {
-    logic [ni_params_pkg::NOC_ID_WIDTH_DFLT-1:0]     awid;
+    logic [ni_params_pkg::AXI_ID_WIDTH_DFLT-1:0]     awid;
     logic [ni_params_pkg::AXI_ADDR_WIDTH_DFLT-1:0]   awaddr;
     logic [7:0]                                      awlen;
     logic [2:0]                                      awsize;
@@ -123,7 +123,7 @@ package ni_signals_pkg;
     logic                                            wlast;
     logic                                            wvalid;
     logic                                            bready;
-    logic [ni_params_pkg::NOC_ID_WIDTH_DFLT-1:0]     arid;
+    logic [ni_params_pkg::AXI_ID_WIDTH_DFLT-1:0]     arid;
     logic [ni_params_pkg::AXI_ADDR_WIDTH_DFLT-1:0]   araddr;
     logic [7:0]                                      arlen;
     logic [2:0]                                      arsize;
@@ -139,11 +139,11 @@ package ni_signals_pkg;
   typedef struct packed {
     logic                                          awready;
     logic                                          wready;
-    logic [ni_params_pkg::NOC_ID_WIDTH_DFLT-1:0]   bid;
+    logic [ni_params_pkg::AXI_ID_WIDTH_DFLT-1:0]   bid;
     logic [1:0]                                    bresp;
     logic                                          bvalid;
     logic                                          arready;
-    logic [ni_params_pkg::NOC_ID_WIDTH_DFLT-1:0]   rid;
+    logic [ni_params_pkg::AXI_ID_WIDTH_DFLT-1:0]   rid;
     logic [ni_params_pkg::AXI_DATA_WIDTH_DFLT-1:0] rdata;
     logic [1:0]                                    rresp;
     logic                                          rlast;

--- a/specgen/source/interface_handshake.json
+++ b/specgen/source/interface_handshake.json
@@ -4,7 +4,7 @@
     "axi4_intf": {
       "kind": "axi4",
       "parameters": [
-        { "name": "ID_WIDTH",   "constants_yaml_key": "axi.NOC_ID_WIDTH"   },
+        { "name": "ID_WIDTH",   "constants_yaml_key": "axi.AXI_ID_WIDTH"   },
         { "name": "ADDR_WIDTH", "constants_yaml_key": "axi.ADDR_WIDTH" },
         { "name": "DATA_WIDTH", "constants_yaml_key": "axi.DATA_WIDTH" }
       ],

--- a/specgen/tests/golden/ni_signals_pkg.sv.golden
+++ b/specgen/tests/golden/ni_signals_pkg.sv.golden
@@ -75,7 +75,7 @@ package ni_signals_pkg;
     logic [2:0]                                    awsize;
     logic [7:0]                                    awlen;
     logic [ni_params_pkg::AXI_ADDR_WIDTH_DFLT-1:0] awaddr;
-    logic [ni_params_pkg::NOC_ID_WIDTH_DFLT-1:0]   awid;
+    logic [ni_params_pkg::AXI_ID_WIDTH_DFLT-1:0]   awid;
   } axi_aw_t;
   typedef struct packed {
     logic [ni_params_pkg::AXI_DATA_WIDTH_DFLT-1:0]   wdata;
@@ -84,7 +84,7 @@ package ni_signals_pkg;
   } axi_w_t;
   typedef struct packed {
     logic [1:0]                                  bresp;
-    logic [ni_params_pkg::NOC_ID_WIDTH_DFLT-1:0] bid;
+    logic [ni_params_pkg::AXI_ID_WIDTH_DFLT-1:0] bid;
   } axi_b_t;
   typedef struct packed {
     logic [3:0]                                    arqos;
@@ -96,18 +96,18 @@ package ni_signals_pkg;
     logic [2:0]                                    arsize;
     logic [7:0]                                    arlen;
     logic [ni_params_pkg::AXI_ADDR_WIDTH_DFLT-1:0] araddr;
-    logic [ni_params_pkg::NOC_ID_WIDTH_DFLT-1:0]   arid;
+    logic [ni_params_pkg::AXI_ID_WIDTH_DFLT-1:0]   arid;
   } axi_ar_t;
   typedef struct packed {
     logic [ni_params_pkg::AXI_DATA_WIDTH_DFLT-1:0] rdata;
     logic [1:0]                                    rresp;
-    logic [ni_params_pkg::NOC_ID_WIDTH_DFLT-1:0]   rid;
+    logic [ni_params_pkg::AXI_ID_WIDTH_DFLT-1:0]   rid;
     logic                                          rlast;
   } axi_r_t;
 
   // AXI wrap-port aggregates (widths fixed-default).
   typedef struct packed {
-    logic [ni_params_pkg::NOC_ID_WIDTH_DFLT-1:0]     awid;
+    logic [ni_params_pkg::AXI_ID_WIDTH_DFLT-1:0]     awid;
     logic [ni_params_pkg::AXI_ADDR_WIDTH_DFLT-1:0]   awaddr;
     logic [7:0]                                      awlen;
     logic [2:0]                                      awsize;
@@ -123,7 +123,7 @@ package ni_signals_pkg;
     logic                                            wlast;
     logic                                            wvalid;
     logic                                            bready;
-    logic [ni_params_pkg::NOC_ID_WIDTH_DFLT-1:0]     arid;
+    logic [ni_params_pkg::AXI_ID_WIDTH_DFLT-1:0]     arid;
     logic [ni_params_pkg::AXI_ADDR_WIDTH_DFLT-1:0]   araddr;
     logic [7:0]                                      arlen;
     logic [2:0]                                      arsize;
@@ -139,11 +139,11 @@ package ni_signals_pkg;
   typedef struct packed {
     logic                                          awready;
     logic                                          wready;
-    logic [ni_params_pkg::NOC_ID_WIDTH_DFLT-1:0]   bid;
+    logic [ni_params_pkg::AXI_ID_WIDTH_DFLT-1:0]   bid;
     logic [1:0]                                    bresp;
     logic                                          bvalid;
     logic                                          arready;
-    logic [ni_params_pkg::NOC_ID_WIDTH_DFLT-1:0]   rid;
+    logic [ni_params_pkg::AXI_ID_WIDTH_DFLT-1:0]   rid;
     logic [ni_params_pkg::AXI_DATA_WIDTH_DFLT-1:0] rdata;
     logic [1:0]                                    rresp;
     logic                                          rlast;

--- a/specgen/tests/test_codegen_sv.py
+++ b/specgen/tests/test_codegen_sv.py
@@ -177,6 +177,12 @@ class TestSvSignalsEmit:
         for type_name in ("axi_aw_t", "axi_w_t", "axi_b_t", "axi_ar_t", "axi_r_t"):
             assert f"}} {type_name};" in sv
 
+    def test_axi_ids_use_external_width(self):
+        sv = (RTL_PKG_DIR / "ni_signals_pkg.sv").read_text(encoding="ascii")
+        axi_types = sv[sv.index("typedef struct packed {"):sv.index("} axi_rsp_t;")]
+        assert "AXI_ID_WIDTH_DFLT-1:0" in axi_types
+        assert "NOC_ID_WIDTH_DFLT-1:0" not in axi_types
+
     def test_struct_typedefs_in_package(self):
         sv = (RTL_PKG_DIR / "ni_signals_pkg.sv").read_text(encoding="ascii")
         pkg = sv[sv.index("package ni_signals_pkg"):sv.index("endpackage")]

--- a/specgen/tools/elaborate/sv_signals.py
+++ b/specgen/tools/elaborate/sv_signals.py
@@ -123,7 +123,7 @@ _AXI_PAYLOAD_FIELD_LSB_ORDER: dict[str, list[str]] = {
 # Interface uses parameterized widths; struct must use fully-qualified pkg refs.
 # ---------------------------------------------------------------------------
 _IFACE_WIDTH_TO_STRUCT: dict[str, str] = {
-    "[ID_WIDTH-1:0]":   "[ni_params_pkg::NOC_ID_WIDTH_DFLT-1:0]",
+    "[ID_WIDTH-1:0]":   "[ni_params_pkg::AXI_ID_WIDTH_DFLT-1:0]",
     "[ADDR_WIDTH-1:0]": "[ni_params_pkg::AXI_ADDR_WIDTH_DFLT-1:0]",
     "[DATA_WIDTH-1:0]": "[ni_params_pkg::AXI_DATA_WIDTH_DFLT-1:0]",
     "[WSTRB_WIDTH-1:0]": "[ni_params_pkg::AXI_DATA_WIDTH_DFLT/8-1:0]",


### PR DESCRIPTION
Closes #75\n\nAdds the interface-only NMU top shell and focused canonical elaboration check. No datapath or storage is implemented.