### PR TITLE
feat(nmu): add request-side AXI FIFOs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -157,6 +157,12 @@ rtl-id-remap-test:
 rtl-nmu-paths-test:
 	@$(PYTHON3) scripts/test_nmu_paths.py
 
+rtl-nmu-lint:
+	@bash rtl/nmu/test.sh lint
+
+rtl-nmu-test:
+	@bash rtl/nmu/test.sh test
+
 PYTHON3 ?= python3
 
 # Python suites: specgen (codegen/golden drift gate -- a stale golden, e.g. an

--- a/rtl/Bender.yml
+++ b/rtl/Bender.yml
@@ -5,14 +5,16 @@ package:
 dependencies:
   common_cells:
     git: https://github.com/pulp-platform/common_cells.git
-    rev: 63b7c50d43e462b59506f69d341ff1e40202866d
+    rev: 9ca8a7655f741e7dd5736669a20a301325194c28
 
 sources:
   - common/axi_if.sv
   - common/ni_child_types_pkg.sv
   - common/ni_sam.sv
   - common/stream_register.sv
+  - common/axi_async_fifo.sv
   - nmu/nmu_sam.sv
   - nmu/nmu_request_path.sv
   - nmu/nmu_response_path.sv
   - nmu/nmu.sv
+  - nmu/nmu_request_fifo.sv

--- a/rtl/common/axi_async_fifo.sv
+++ b/rtl/common/axi_async_fifo.sv
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: Apache-2.0
+
+`resetall
+`timescale 1ns / 1ps
+`default_nettype none
+
+/* Ready/valid adapter for the production Gray-pointer CDC FIFO primitive. */
+module axi_async_fifo #(
+    // AXI channel FIFO depth in entries.
+    parameter int unsigned AXI_FIFO_DEPTH = 8,
+    // Complete AXI channel record type.
+    parameter type T = logic
+) (
+    input  wire logic  src_clk_i,
+    input  wire logic  src_rst_ni,
+    input  wire logic  src_valid_i,
+    output wire logic  src_ready_o,
+    input  wire T      src_data_i,
+    input  wire logic  dst_clk_i,
+    input  wire logic  dst_rst_ni,
+    output wire logic  dst_valid_o,
+    input  wire logic  dst_ready_i,
+    output wire T      dst_data_o
+);
+
+    localparam int unsigned CL_AXI_FIFO_DEPTH = $clog2(AXI_FIFO_DEPTH);
+
+    if (AXI_FIFO_DEPTH < 2 || (AXI_FIFO_DEPTH & (AXI_FIFO_DEPTH - 1)) != 0) begin : gen_invalid_depth
+        initial $fatal(0, "Error: AXI_FIFO_DEPTH must be a power of two and at least 2 (instance %m)");
+    end
+
+    cdc_fifo_gray #(
+        .T           ( T                 ),
+        .LOG_DEPTH   ( CL_AXI_FIFO_DEPTH ),
+        .SYNC_STAGES ( 2                 )
+    ) i_cdc_fifo_gray (
+        .src_rst_ni,
+        .src_clk_i,
+        .src_data_i,
+        .src_valid_i,
+        .src_ready_o,
+        .dst_rst_ni,
+        .dst_clk_i,
+        .dst_data_o,
+        .dst_valid_o,
+        .dst_ready_i
+    );
+
+endmodule
+
+`resetall

--- a/rtl/nmu/nmu_request_fifo.sv
+++ b/rtl/nmu/nmu_request_fifo.sv
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: Apache-2.0
+
+`resetall
+`timescale 1ns / 1ps
+`default_nettype none
+
+/* AXI-clock to NoC-clock request-channel FIFO bank. */
+module nmu_request_fifo #(
+    // Common request-channel FIFO depth in entries.
+    parameter int unsigned AXI_FIFO_DEPTH = 8,
+    // External AXI ID width; request records retain this width across CDC.
+    parameter int unsigned AXI_ID_WIDTH = 3,
+    // Complete write-address channel record type.
+    parameter type AW_T = logic [AXI_ID_WIDTH-1:0],
+    // Complete write-data channel record type.
+    parameter type W_T = logic,
+    // Complete read-address channel record type.
+    parameter type AR_T = logic [AXI_ID_WIDTH-1:0]
+) (
+    input  wire logic  axi_clk_i,
+    input  wire logic  axi_rst_ni,
+    input  wire logic  noc_clk_i,
+    input  wire logic  noc_rst_ni,
+
+    input  wire logic  s_aw_valid_i,
+    output wire logic  s_aw_ready_o,
+    input  wire AW_T   s_aw_data_i,
+    output wire logic  m_aw_valid_o,
+    input  wire logic  m_aw_ready_i,
+    output wire AW_T   m_aw_data_o,
+
+    input  wire logic  s_w_valid_i,
+    output wire logic  s_w_ready_o,
+    input  wire W_T    s_w_data_i,
+    output wire logic  m_w_valid_o,
+    input  wire logic  m_w_ready_i,
+    output wire W_T    m_w_data_o,
+
+    input  wire logic  s_ar_valid_i,
+    output wire logic  s_ar_ready_o,
+    input  wire AR_T   s_ar_data_i,
+    output wire logic  m_ar_valid_o,
+    input  wire logic  m_ar_ready_i,
+    output wire AR_T   m_ar_data_o
+);
+
+    if (AXI_FIFO_DEPTH < 2 || (AXI_FIFO_DEPTH & (AXI_FIFO_DEPTH - 1)) != 0) begin : gen_invalid_depth
+        initial $fatal(0, "Error: AXI_FIFO_DEPTH must be a power of two and at least 2 (instance %m)");
+    end
+
+    if (AXI_ID_WIDTH < 1 || AXI_ID_WIDTH > 8) begin : gen_invalid_axi_id_width
+        initial $fatal(0, "Error: AXI_ID_WIDTH must be between 1 and 8 (instance %m)");
+    end
+
+    axi_async_fifo #(
+        .AXI_FIFO_DEPTH ( AXI_FIFO_DEPTH ),
+        .T              ( AW_T           )
+    ) i_aw_fifo (
+        .src_clk_i   ( axi_clk_i    ),
+        .src_rst_ni  ( axi_rst_ni   ),
+        .src_valid_i ( s_aw_valid_i ),
+        .src_ready_o ( s_aw_ready_o ),
+        .src_data_i  ( s_aw_data_i  ),
+        .dst_clk_i   ( noc_clk_i    ),
+        .dst_rst_ni  ( noc_rst_ni   ),
+        .dst_valid_o ( m_aw_valid_o ),
+        .dst_ready_i ( m_aw_ready_i ),
+        .dst_data_o  ( m_aw_data_o  )
+    );
+
+    axi_async_fifo #(
+        .AXI_FIFO_DEPTH ( AXI_FIFO_DEPTH ),
+        .T              ( W_T            )
+    ) i_w_fifo (
+        .src_clk_i   ( axi_clk_i   ),
+        .src_rst_ni  ( axi_rst_ni  ),
+        .src_valid_i ( s_w_valid_i ),
+        .src_ready_o ( s_w_ready_o ),
+        .src_data_i  ( s_w_data_i  ),
+        .dst_clk_i   ( noc_clk_i   ),
+        .dst_rst_ni  ( noc_rst_ni  ),
+        .dst_valid_o ( m_w_valid_o ),
+        .dst_ready_i ( m_w_ready_i ),
+        .dst_data_o  ( m_w_data_o  )
+    );
+
+    axi_async_fifo #(
+        .AXI_FIFO_DEPTH ( AXI_FIFO_DEPTH ),
+        .T              ( AR_T           )
+    ) i_ar_fifo (
+        .src_clk_i   ( axi_clk_i    ),
+        .src_rst_ni  ( axi_rst_ni   ),
+        .src_valid_i ( s_ar_valid_i ),
+        .src_ready_o ( s_ar_ready_o ),
+        .src_data_i  ( s_ar_data_i  ),
+        .dst_clk_i   ( noc_clk_i    ),
+        .dst_rst_ni  ( noc_rst_ni   ),
+        .dst_valid_o ( m_ar_valid_o ),
+        .dst_ready_i ( m_ar_ready_i ),
+        .dst_data_o  ( m_ar_data_o  )
+    );
+
+endmodule
+
+`resetall

--- a/rtl/nmu/test.sh
+++ b/rtl/nmu/test.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+task_mode=${1:-test}
+task_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
+task_manifest="$task_root/rtl/Bender.yml"
+task_revision=9ca8a7655f741e7dd5736669a20a301325194c28
+task_tmp=$(mktemp -d "${TMPDIR:-/tmp}/nmu-request-fifo-XXXXXX")
+trap 'rm -rf "$task_tmp"' EXIT
+
+if [[ -n "${COMMON_CELLS_DIR:-}" ]]; then
+    task_common_cells=$COMMON_CELLS_DIR
+else
+    task_common_cells="$task_tmp/common_cells"
+    git clone --quiet https://github.com/pulp-platform/common_cells.git "$task_common_cells"
+    git -C "$task_common_cells" checkout --quiet "$task_revision"
+fi
+
+[[ $(git -C "$task_common_cells" rev-parse HEAD) == "$task_revision" ]]
+grep -Fq "$task_revision" "$task_manifest"
+
+task_sources=(
+    "$task_common_cells/src/binary_to_gray.sv"
+    "$task_common_cells/src/gray_to_binary.sv"
+    "$task_common_cells/src/spill_register_flushable.sv"
+    "$task_common_cells/src/spill_register.sv"
+    "$task_common_cells/src/stream_register.sv"
+    "$task_common_cells/src/sync.sv"
+    "$task_common_cells/src/cdc_fifo_gray.sv"
+    "$task_root/rtl/common/axi_async_fifo.sv"
+    "$task_root/rtl/nmu/nmu_request_fifo.sv"
+    "$task_root/rtl/nmu/tests/tb_nmu_request_fifo.sv"
+    "$task_root/rtl/nmu/tests/tb_nmu_request_fifo_guards.sv"
+)
+
+task_verilator=(
+    verilator --timing --assert -Wall -Wno-fatal -Wno-DECLFILENAME -Wno-TIMESCALEMOD
+    -Wno-UNUSEDPARAM -Wno-UNUSEDSIGNAL -Wno-SYNCASYNCNET -Wno-PINCONNECTEMPTY
+    -I"$task_common_cells/include" --top-module tb_nmu_request_fifo
+)
+
+task_guard_messages=(
+    "AXI_FIFO_DEPTH must be a power of two and at least 2"
+    "AXI_ID_WIDTH must be between 1 and 8"
+    "AXI_ID_WIDTH must be between 1 and 8"
+)
+
+case "$task_mode" in
+    lint)
+        "${task_verilator[@]}" --lint-only "${task_sources[@]}"
+        ;;
+    test)
+        "${task_verilator[@]}" --lint-only "${task_sources[@]}"
+        for task_depth in 2 8 32; do
+            for task_id_width in 1 3 8; do
+                task_obj_dir="$task_tmp/obj_dir_${task_depth}_${task_id_width}"
+                "${task_verilator[@]}" \
+                    -GAXI_FIFO_DEPTH="$task_depth" \
+                    -GAXI_ID_WIDTH="$task_id_width" \
+                    --binary --Mdir "$task_obj_dir" -o nmu_request_fifo_tb \
+                    "${task_sources[@]}"
+                "$task_obj_dir/nmu_request_fifo_tb"
+            done
+        done
+        for task_case in 0 1 2; do
+            task_obj_dir="$task_tmp/obj_dir_invalid_$task_case"
+            task_log="$task_tmp/guard_$task_case.log"
+            "${task_verilator[@]}" \
+                --top-module tb_nmu_request_fifo_guards \
+                -GINVALID_CASE="$task_case" \
+                --binary --Mdir "$task_obj_dir" -o nmu_request_fifo_guards_tb \
+                "${task_sources[@]}"
+            if "$task_obj_dir/nmu_request_fifo_guards_tb" >"$task_log" 2>&1; then
+                echo "request FIFO parameter guard $task_case did not fail" >&2
+                exit 1
+            fi
+            if ! grep -Fq "${task_guard_messages[$task_case]}" "$task_log"; then
+                cat "$task_log" >&2
+                echo "request FIFO parameter guard $task_case failed for an unexpected reason" >&2
+                exit 1
+            fi
+        done
+        ;;
+    *)
+        echo "usage: $0 [lint|test]" >&2
+        exit 2
+        ;;
+esac

--- a/rtl/nmu/tests/tb_nmu_request_fifo.sv
+++ b/rtl/nmu/tests/tb_nmu_request_fifo.sv
@@ -1,0 +1,265 @@
+`resetall
+`timescale 1ns / 1ps
+`default_nettype none
+
+module tb_nmu_request_fifo #(
+    parameter int unsigned AXI_FIFO_DEPTH = 8,
+    parameter int unsigned AXI_ID_WIDTH = 3
+);
+
+    typedef struct packed {
+        logic [AXI_ID_WIDTH-1:0] id;
+        logic [7:0]              tag;
+        logic [7:0]              len;
+    } aw_t;
+
+    typedef logic [8:0] w_t;
+
+    typedef struct packed {
+        logic [AXI_ID_WIDTH-1:0] id;
+        logic [7:0]              tag;
+    } ar_t;
+
+    logic axi_clk_i = 1'b0;
+    logic axi_rst_ni = 1'b0;
+    logic noc_clk_i = 1'b0;
+    logic noc_rst_ni = 1'b0;
+
+    logic s_aw_valid;
+    logic s_aw_ready;
+    aw_t  s_aw_data;
+    logic m_aw_valid;
+    logic m_aw_ready;
+    aw_t  m_aw_data;
+
+    logic s_w_valid;
+    logic s_w_ready;
+    w_t   s_w_data;
+    logic m_w_valid;
+    logic m_w_ready;
+    w_t   m_w_data;
+
+    logic s_ar_valid;
+    logic s_ar_ready;
+    ar_t  s_ar_data;
+    logic m_ar_valid;
+    logic m_ar_ready;
+    ar_t  m_ar_data;
+
+    nmu_request_fifo #(
+        .AXI_FIFO_DEPTH ( AXI_FIFO_DEPTH ),
+        .AXI_ID_WIDTH   ( AXI_ID_WIDTH   ),
+        .AW_T           ( aw_t           ),
+        .W_T            ( w_t            ),
+        .AR_T           ( ar_t           )
+    ) dut (
+        .axi_clk_i,
+        .axi_rst_ni,
+        .noc_clk_i,
+        .noc_rst_ni,
+        .s_aw_valid_i ( s_aw_valid ),
+        .s_aw_ready_o ( s_aw_ready ),
+        .s_aw_data_i  ( s_aw_data  ),
+        .m_aw_valid_o ( m_aw_valid ),
+        .m_aw_ready_i ( m_aw_ready ),
+        .m_aw_data_o  ( m_aw_data  ),
+        .s_w_valid_i  ( s_w_valid  ),
+        .s_w_ready_o  ( s_w_ready  ),
+        .s_w_data_i   ( s_w_data   ),
+        .m_w_valid_o  ( m_w_valid  ),
+        .m_w_ready_i  ( m_w_ready  ),
+        .m_w_data_o   ( m_w_data   ),
+        .s_ar_valid_i ( s_ar_valid ),
+        .s_ar_ready_o ( s_ar_ready ),
+        .s_ar_data_i  ( s_ar_data  ),
+        .m_ar_valid_o ( m_ar_valid ),
+        .m_ar_ready_i ( m_ar_ready ),
+        .m_ar_data_o  ( m_ar_data  )
+    );
+
+    always #5ns axi_clk_i <= ~axi_clk_i;
+    always #7ns noc_clk_i <= ~noc_clk_i;
+
+    initial begin
+        #100us;
+        $fatal(1, "Timed out waiting for NMU request FIFO test completion");
+    end
+
+    function automatic w_t make_w(input logic [7:0] tag, input logic last);
+        make_w = {tag, last};
+    endfunction
+
+    task automatic send_aw(input aw_t data);
+        begin
+            @(negedge axi_clk_i);
+            s_aw_data = data;
+            s_aw_valid = 1'b1;
+            do @(posedge axi_clk_i); while (!s_aw_ready);
+            @(negedge axi_clk_i);
+            s_aw_valid = 1'b0;
+        end
+    endtask
+
+    task automatic send_w(input w_t data);
+        begin
+            @(negedge axi_clk_i);
+            s_w_data = data;
+            s_w_valid = 1'b1;
+            do @(posedge axi_clk_i); while (!s_w_ready);
+            @(negedge axi_clk_i);
+            s_w_valid = 1'b0;
+        end
+    endtask
+
+    task automatic send_ar(input ar_t data);
+        begin
+            @(negedge axi_clk_i);
+            s_ar_data = data;
+            s_ar_valid = 1'b1;
+            do @(posedge axi_clk_i); while (!s_ar_ready);
+            @(negedge axi_clk_i);
+            s_ar_valid = 1'b0;
+        end
+    endtask
+
+    task automatic receive_aw(input aw_t expected);
+        begin
+            wait (m_aw_valid === 1'b1);
+            #1ps;
+            assert (m_aw_data == expected)
+                else $fatal(1, "AW FIFO expected tag %0h, got %0h", expected.tag, m_aw_data.tag);
+            @(negedge noc_clk_i);
+            m_aw_ready = 1'b1;
+            @(posedge noc_clk_i);
+            @(negedge noc_clk_i);
+            m_aw_ready = 1'b0;
+        end
+    endtask
+
+    task automatic receive_w(input w_t expected);
+        begin
+            wait (m_w_valid === 1'b1);
+            #1ps;
+            assert (m_w_data == expected)
+                else $fatal(1, "W FIFO expected %0h, got %0h", expected, m_w_data);
+            @(negedge noc_clk_i);
+            m_w_ready = 1'b1;
+            @(posedge noc_clk_i);
+            @(negedge noc_clk_i);
+            m_w_ready = 1'b0;
+        end
+    endtask
+
+    task automatic receive_ar(input ar_t expected);
+        begin
+            wait (m_ar_valid === 1'b1);
+            #1ps;
+            assert (m_ar_data == expected)
+                else $fatal(1, "AR FIFO expected tag %0h, got %0h", expected.tag, m_ar_data.tag);
+            @(negedge noc_clk_i);
+            m_ar_ready = 1'b1;
+            @(posedge noc_clk_i);
+            @(negedge noc_clk_i);
+            m_ar_ready = 1'b0;
+        end
+    endtask
+
+    initial begin
+        aw_t aw_data;
+        w_t w_data;
+        ar_t ar_data;
+        int unsigned aw_fill_count;
+
+        s_aw_valid = 1'b0;
+        s_aw_data = '0;
+        m_aw_ready = 1'b0;
+        s_w_valid = 1'b0;
+        s_w_data = '0;
+        m_w_ready = 1'b0;
+        s_ar_valid = 1'b0;
+        s_ar_data = '0;
+        m_ar_ready = 1'b0;
+
+        repeat (3) @(posedge axi_clk_i);
+        #1ps;
+        axi_rst_ni = 1'b1;
+        repeat (3) @(posedge noc_clk_i);
+        #1ps;
+        noc_rst_ni = 1'b1;
+        assert (!m_aw_valid && !m_w_valid && !m_ar_valid)
+            else $fatal(1, "Request FIFO output valid was not cleared by reset");
+
+        // A full AW FIFO must not backpressure the independent W and AR channels.
+        aw_fill_count = 0;
+        while (s_aw_ready && aw_fill_count < AXI_FIFO_DEPTH + 4) begin
+            int unsigned index;
+            index = aw_fill_count;
+            aw_data.id = AXI_ID_WIDTH'(index);
+            aw_data.tag = 8'h10 + 8'(index);
+            aw_data.len = 8'd0;
+            send_aw(aw_data);
+            aw_fill_count++;
+            #1ps;
+        end
+        assert (!s_aw_ready) else $fatal(1, "AW FIFO did not become full");
+        assert (s_w_ready && s_ar_ready)
+            else $fatal(1, "Full AW FIFO backpressured W or AR");
+
+        w_data = make_w(8'ha0, 1'b1);
+        ar_data.id = AXI_ID_WIDTH'(0);
+        ar_data.tag = 8'hb0;
+        send_w(w_data);
+        send_ar(ar_data);
+        receive_w(w_data);
+        receive_ar(ar_data);
+
+        // Drain AW in FIFO order and confirm source readiness returns after CDC synchronization.
+        for (int unsigned index = 0; index < aw_fill_count; index++) begin
+            aw_data.id = AXI_ID_WIDTH'(index);
+            aw_data.tag = 8'h10 + 8'(index);
+            aw_data.len = 8'd0;
+            receive_aw(aw_data);
+        end
+        repeat (3) @(posedge axi_clk_i);
+        assert (s_aw_ready) else $fatal(1, "AW FIFO did not release source backpressure");
+
+        // Preserve AW order and W-beat order: the following metadata stage can associate
+        // the two bursts by their accepted AW/W sequence.
+        aw_data.id = AXI_ID_WIDTH'(1);
+        aw_data.tag = 8'hc0;
+        aw_data.len = 8'd1;
+        send_aw(aw_data);
+        aw_data.id = AXI_ID_WIDTH'(2);
+        aw_data.tag = 8'hd0;
+        aw_data.len = 8'd0;
+        send_aw(aw_data);
+
+        w_data = make_w(8'hc1, 1'b0);
+        send_w(w_data);
+        w_data = make_w(8'hc2, 1'b1);
+        send_w(w_data);
+        w_data = make_w(8'hd1, 1'b1);
+        send_w(w_data);
+
+        aw_data.id = AXI_ID_WIDTH'(1);
+        aw_data.tag = 8'hc0;
+        aw_data.len = 8'd1;
+        receive_aw(aw_data);
+        aw_data.id = AXI_ID_WIDTH'(2);
+        aw_data.tag = 8'hd0;
+        aw_data.len = 8'd0;
+        receive_aw(aw_data);
+        w_data = make_w(8'hc1, 1'b0);
+        receive_w(w_data);
+        w_data = make_w(8'hc2, 1'b1);
+        receive_w(w_data);
+        w_data = make_w(8'hd1, 1'b1);
+        receive_w(w_data);
+
+        $display("PASS: NMU request FIFO");
+        $finish;
+    end
+
+endmodule
+
+`resetall

--- a/rtl/nmu/tests/tb_nmu_request_fifo_guards.sv
+++ b/rtl/nmu/tests/tb_nmu_request_fifo_guards.sv
@@ -1,0 +1,84 @@
+`resetall
+`timescale 1ns / 1ps
+`default_nettype none
+
+module tb_nmu_request_fifo_guards #(
+    parameter int unsigned INVALID_CASE = 0
+);
+
+    logic axi_clk_i = 1'b0;
+    logic axi_rst_ni = 1'b0;
+    logic noc_clk_i = 1'b0;
+    logic noc_rst_ni = 1'b0;
+    logic s_ready;
+    logic m_valid;
+
+    if (INVALID_CASE == 0) begin : gen_invalid_depth
+        nmu_request_fifo #(
+            .AXI_FIFO_DEPTH ( 3 )
+        ) dut (
+            .axi_clk_i,
+            .axi_rst_ni,
+            .noc_clk_i,
+            .noc_rst_ni,
+            .s_aw_valid_i ( 1'b0 ),
+            .s_aw_ready_o ( s_ready ),
+            .s_aw_data_i  ( '0 ),
+            .m_aw_valid_o ( m_valid ),
+            .m_aw_ready_i ( 1'b0 ),
+            .m_aw_data_o  ( ),
+            .s_w_valid_i  ( 1'b0 ),
+            .s_w_ready_o  ( ),
+            .s_w_data_i   ( '0 ),
+            .m_w_valid_o  ( ),
+            .m_w_ready_i  ( 1'b0 ),
+            .m_w_data_o   ( ),
+            .s_ar_valid_i ( 1'b0 ),
+            .s_ar_ready_o ( ),
+            .s_ar_data_i  ( '0 ),
+            .m_ar_valid_o ( ),
+            .m_ar_ready_i ( 1'b0 ),
+            .m_ar_data_o  ( )
+        );
+    end else if (INVALID_CASE == 1) begin : gen_invalid_axi_id_width_low
+        nmu_request_fifo #(
+            .AXI_ID_WIDTH ( 0 )
+        ) dut (
+            .axi_clk_i,
+            .axi_rst_ni,
+            .noc_clk_i,
+            .noc_rst_ni,
+            .s_aw_valid_i ( 1'b0 ), .s_aw_ready_o ( s_ready ), .s_aw_data_i ( '0 ),
+            .m_aw_valid_o ( m_valid ), .m_aw_ready_i ( 1'b0 ), .m_aw_data_o ( ),
+            .s_w_valid_i ( 1'b0 ), .s_w_ready_o ( ), .s_w_data_i ( '0 ),
+            .m_w_valid_o ( ), .m_w_ready_i ( 1'b0 ), .m_w_data_o ( ),
+            .s_ar_valid_i ( 1'b0 ), .s_ar_ready_o ( ), .s_ar_data_i ( '0 ),
+            .m_ar_valid_o ( ), .m_ar_ready_i ( 1'b0 ), .m_ar_data_o ( )
+        );
+    end else if (INVALID_CASE == 2) begin : gen_invalid_axi_id_width_high
+        nmu_request_fifo #(
+            .AXI_ID_WIDTH ( 9 )
+        ) dut (
+            .axi_clk_i,
+            .axi_rst_ni,
+            .noc_clk_i,
+            .noc_rst_ni,
+            .s_aw_valid_i ( 1'b0 ), .s_aw_ready_o ( s_ready ), .s_aw_data_i ( '0 ),
+            .m_aw_valid_o ( m_valid ), .m_aw_ready_i ( 1'b0 ), .m_aw_data_o ( ),
+            .s_w_valid_i ( 1'b0 ), .s_w_ready_o ( ), .s_w_data_i ( '0 ),
+            .m_w_valid_o ( ), .m_w_ready_i ( 1'b0 ), .m_w_data_o ( ),
+            .s_ar_valid_i ( 1'b0 ), .s_ar_ready_o ( ), .s_ar_data_i ( '0 ),
+            .m_ar_valid_o ( ), .m_ar_ready_i ( 1'b0 ), .m_ar_data_o ( )
+        );
+    end else begin : gen_invalid_case
+        initial $fatal(0, "Error: INVALID_CASE must select one request FIFO guard (instance %m)");
+    end
+
+    initial begin
+        #10ns;
+        $finish;
+    end
+
+endmodule
+
+`resetall


### PR DESCRIPTION
Closes #77

Adds independent AW/W/AR AXI-to-NoC CDC FIFOs using the approved common_cells cdc_fifo_gray primitive through axi_async_fifo. FIFO depth and AXI_ID_WIDTH are parameterized. Focused Verilator tests cover channel independence, ordering, depth 2/8/32, ID width 1/3/8, and parameter guards.

Verified with clean before and after: make rtl-nmu-lint and make rtl-nmu-test.