### PR TITLE
feat(nmu): define request-response control interface

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ CMODEL_BUILD     = $(BUILD_ROOT)/cmodel
 SIM_VERILATOR := sim/verilator
 SIM_VCS       := sim/vcs
 
-.PHONY: help build build-cmodel build-yamlcpp build-verilator test rtl-sam-lint rtl-sam-test rtl-id-remap-test rtl-nmu-paths-test \
+.PHONY: help build build-cmodel build-yamlcpp build-verilator test rtl-sam-lint rtl-sam-test rtl-id-remap-test rtl-nmu-paths-test rtl-nmu-ctrl-test \
         pytest check docker-build docker-shell docker-test docker-pytest docker-sim-setup docker-sim-smoke docker-sim-tier2 \
         clean clean-cmodel clean-verilator clean-vcs clean-generated
 
@@ -162,6 +162,9 @@ rtl-nmu-lint:
 
 rtl-nmu-test:
 	@bash rtl/nmu/test.sh test
+
+rtl-nmu-ctrl-test:
+	@bash rtl/nmu/test_req_rsp_ctrl.sh
 
 PYTHON3 ?= python3
 

--- a/docs/trade-off.md
+++ b/docs/trade-off.md
@@ -566,3 +566,14 @@ leaking into generic request-path, CDC, FIFO, and testbench boundaries. The cost
 and CDC-width increase is required because AWUSER must remain associated with AW through the
 request path; dropping or carrying it in a parallel untyped sideband would make the channel
 contract easier to misuse.
+
+## NMU request-response control boundary
+
+The request and response paths communicate through four independent ready/valid lanes:
+AW admission, AR admission, B retirement, and R retirement. Admission carries AXI ID, burst
+length, SAM-derived destination ID/port, and AXI class. The ordering unit returns ordering
+request/tag metadata; retirement returns AXI ID, ordering metadata, and last.
+
+This keeps AXI payload and NoC flit interfaces separate, preserves AW/AR and B/R parallelism,
+and adds no storage or arbitration to the boundary. The cost is a wider control interface and
+the requirement that the later ResponseBuffer implement four independent handshake paths.

--- a/rtl/Bender.yml
+++ b/rtl/Bender.yml
@@ -9,6 +9,7 @@ dependencies:
 
 sources:
   - common/axi_if.sv
+  - common/nmu_req_rsp_ctrl_if.sv
   - common/ni_child_types_pkg.sv
   - common/ni_sam.sv
   - common/stream_register.sv
@@ -18,3 +19,4 @@ sources:
   - nmu/nmu_response_path.sv
   - nmu/nmu.sv
   - nmu/nmu_request_fifo.sv
+  - nmu/nmu_req_rsp_ctrl_shell.sv

--- a/rtl/common/nmu_req_rsp_ctrl_if.sv
+++ b/rtl/common/nmu_req_rsp_ctrl_if.sv
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: Apache-2.0
+
+`resetall
+`timescale 1ns / 1ps
+`default_nettype none
+
+interface nmu_req_rsp_ctrl_if #(
+    parameter int unsigned AXI_ID_WIDTH = ni_params_pkg::AXI_ID_WIDTH_DFLT,
+    parameter int unsigned MAX_TXNS_PER_ID = ni_params_pkg::NMU_MAX_TXNS_PER_ID_DFLT
+);
+
+    localparam int unsigned AXI_LEN_WIDTH = ni_flit_pkg::AXI_LEN_WIDTH;
+    localparam int unsigned DST_ID_WIDTH = ni_flit_pkg::DST_ID_WIDTH;
+    localparam int unsigned DST_PORT_ID_WIDTH = ni_flit_pkg::DST_PORT_ID_WIDTH;
+    localparam int unsigned ORDERING_TAG_WIDTH = ni_flit_pkg::ORDERING_TAG_WIDTH;
+
+    if (AXI_ID_WIDTH < 1 || AXI_ID_WIDTH > 8) begin : gen_invalid_axi_id_width
+        initial $fatal(0, "Error: AXI_ID_WIDTH must be between 1 and 8 (instance %m)");
+    end
+    if (MAX_TXNS_PER_ID < 1) begin : gen_invalid_max_txns
+        initial $fatal(0, "Error: MAX_TXNS_PER_ID must be at least 1 (instance %m)");
+    end
+
+    // Request path -> ResponseBuffer: independent AW and AR admission lanes.
+    logic aw_req_valid, aw_req_ready;
+    logic [AXI_ID_WIDTH-1:0] aw_req_axi_id;
+    logic [AXI_LEN_WIDTH-1:0] aw_req_burst_len;
+    logic [DST_ID_WIDTH-1:0] aw_req_dst_id;
+    logic [DST_PORT_ID_WIDTH-1:0] aw_req_dst_port_id;
+    logic aw_req_is_data;
+    logic ar_req_valid, ar_req_ready;
+    logic [AXI_ID_WIDTH-1:0] ar_req_axi_id;
+    logic [AXI_LEN_WIDTH-1:0] ar_req_burst_len;
+    logic [DST_ID_WIDTH-1:0] ar_req_dst_id;
+    logic [DST_PORT_ID_WIDTH-1:0] ar_req_dst_port_id;
+    logic ar_req_is_data;
+
+    // ResponseBuffer -> Request path: ordering metadata stamped on requests.
+    logic aw_rsp_valid, aw_rsp_ready, aw_rsp_ordering_req;
+    logic [ORDERING_TAG_WIDTH-1:0] aw_rsp_ordering_tag;
+    logic ar_rsp_valid, ar_rsp_ready, ar_rsp_ordering_req;
+    logic [ORDERING_TAG_WIDTH-1:0] ar_rsp_ordering_tag;
+
+    // Response path -> ResponseBuffer: independent B and R retirement lanes.
+    logic b_retire_valid, b_retire_ready, b_retire_ordering_req, b_retire_last;
+    logic [AXI_ID_WIDTH-1:0] b_retire_axi_id;
+    logic [ORDERING_TAG_WIDTH-1:0] b_retire_ordering_tag;
+    logic r_retire_valid, r_retire_ready, r_retire_ordering_req, r_retire_last;
+    logic [AXI_ID_WIDTH-1:0] r_retire_axi_id;
+    logic [ORDERING_TAG_WIDTH-1:0] r_retire_ordering_tag;
+
+    modport request_path (
+        output aw_req_valid, output aw_req_axi_id, output aw_req_burst_len,
+        output aw_req_dst_id, output aw_req_dst_port_id, output aw_req_is_data,
+        input aw_req_ready,
+        output ar_req_valid, output ar_req_axi_id, output ar_req_burst_len,
+        output ar_req_dst_id, output ar_req_dst_port_id, output ar_req_is_data,
+        input ar_req_ready,
+        input aw_rsp_valid, input aw_rsp_ordering_req, input aw_rsp_ordering_tag,
+        output aw_rsp_ready,
+        input ar_rsp_valid, input ar_rsp_ordering_req, input ar_rsp_ordering_tag,
+        output ar_rsp_ready,
+        input b_retire_valid, input b_retire_axi_id, input b_retire_ordering_req,
+        input b_retire_ordering_tag, input b_retire_last, output b_retire_ready,
+        input r_retire_valid, input r_retire_axi_id, input r_retire_ordering_req,
+        input r_retire_ordering_tag, input r_retire_last, output r_retire_ready
+    );
+
+    modport response_buffer (
+        input aw_req_valid, input aw_req_axi_id, input aw_req_burst_len,
+        input aw_req_dst_id, input aw_req_dst_port_id, input aw_req_is_data,
+        output aw_req_ready,
+        input ar_req_valid, input ar_req_axi_id, input ar_req_burst_len,
+        input ar_req_dst_id, input ar_req_dst_port_id, input ar_req_is_data,
+        output ar_req_ready,
+        output aw_rsp_valid, output aw_rsp_ordering_req, output aw_rsp_ordering_tag,
+        input aw_rsp_ready,
+        output ar_rsp_valid, output ar_rsp_ordering_req, output ar_rsp_ordering_tag,
+        input ar_rsp_ready,
+        output b_retire_valid, output b_retire_axi_id, output b_retire_ordering_req,
+        output b_retire_ordering_tag, output b_retire_last, input b_retire_ready,
+        output r_retire_valid, output r_retire_axi_id, output r_retire_ordering_req,
+        output r_retire_ordering_tag, output r_retire_last, input r_retire_ready
+    );
+
+endinterface
+
+`resetall

--- a/rtl/nmu/nmu_req_rsp_ctrl_shell.sv
+++ b/rtl/nmu/nmu_req_rsp_ctrl_shell.sv
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: Apache-2.0
+
+`resetall
+`timescale 1ns / 1ps
+`default_nettype none
+
+// Boundary-only shell. Storage and ordering policy belong to the next issue.
+module nmu_req_rsp_ctrl_shell #(
+    parameter int unsigned AXI_ID_WIDTH = ni_params_pkg::AXI_ID_WIDTH_DFLT,
+    parameter int unsigned MAX_TXNS_PER_ID = ni_params_pkg::NMU_MAX_TXNS_PER_ID_DFLT
+) (
+    nmu_req_rsp_ctrl_if.response_buffer ctrl
+);
+
+    initial begin
+        if (AXI_ID_WIDTH < 1 || AXI_ID_WIDTH > 8) begin
+            $fatal(0, "Error: AXI_ID_WIDTH must be between 1 and 8 (instance %m)");
+        end
+        if (MAX_TXNS_PER_ID < 1) begin
+            $fatal(0, "Error: MAX_TXNS_PER_ID must be at least 1 (instance %m)");
+        end
+    end
+
+endmodule
+
+`resetall

--- a/rtl/nmu/test_req_rsp_ctrl.sh
+++ b/rtl/nmu/test_req_rsp_ctrl.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+task_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
+task_tmp=$(mktemp -d "${TMPDIR:-/tmp}/nmu-req-rsp-ctrl-XXXXXX")
+trap 'rm -rf "$task_tmp"' EXIT
+
+task_sources=(
+    "$task_root/specgen/generated/sv/ni_params_pkg.sv"
+    "$task_root/specgen/generated/sv/ni_flit_pkg.sv"
+    "$task_root/rtl/common/nmu_req_rsp_ctrl_if.sv"
+    "$task_root/rtl/nmu/nmu_req_rsp_ctrl_shell.sv"
+    "$task_root/rtl/nmu/tests/tb_nmu_req_rsp_ctrl.sv"
+)
+
+verilator --timing --assert -Wall -Wno-fatal -Wno-DECLFILENAME \
+    --top-module tb_nmu_req_rsp_ctrl --lint-only "${task_sources[@]}"
+for task_id_width in 1 3 8; do
+    verilator --timing --assert -Wall -Wno-fatal -Wno-DECLFILENAME \
+        --top-module tb_nmu_req_rsp_ctrl --lint-only \
+        -GAXI_ID_WIDTH="$task_id_width" "${task_sources[@]}"
+done
+verilator --timing --assert -Wall -Wno-fatal -Wno-DECLFILENAME \
+    --top-module tb_nmu_req_rsp_ctrl --binary --Mdir "$task_tmp/obj_dir" \
+    -o nmu_req_rsp_ctrl_tb "${task_sources[@]}"
+"$task_tmp/obj_dir/nmu_req_rsp_ctrl_tb"

--- a/rtl/nmu/tests/tb_nmu_req_rsp_ctrl.sv
+++ b/rtl/nmu/tests/tb_nmu_req_rsp_ctrl.sv
@@ -1,0 +1,34 @@
+`resetall
+`timescale 1ns / 1ps
+`default_nettype none
+
+module tb_nmu_req_rsp_ctrl #(
+    parameter int unsigned AXI_ID_WIDTH = 3,
+    parameter int unsigned MAX_TXNS_PER_ID = 32
+);
+
+    nmu_req_rsp_ctrl_if #(
+        .AXI_ID_WIDTH    ( AXI_ID_WIDTH ),
+        .MAX_TXNS_PER_ID ( MAX_TXNS_PER_ID )
+    ) ctrl ();
+
+    nmu_req_rsp_ctrl_shell #(
+        .AXI_ID_WIDTH    ( AXI_ID_WIDTH ),
+        .MAX_TXNS_PER_ID ( MAX_TXNS_PER_ID )
+    ) dut ( .ctrl ( ctrl ) );
+
+    initial begin
+        ctrl.aw_req_valid = 1'b0;
+        ctrl.ar_req_valid = 1'b0;
+        ctrl.aw_rsp_ready = 1'b1;
+        ctrl.ar_rsp_ready = 1'b1;
+        ctrl.b_retire_valid = 1'b0;
+        ctrl.r_retire_valid = 1'b0;
+        #1ns;
+        $display("PASS: NMU request-response control interface contract");
+        $finish;
+    end
+
+endmodule
+
+`resetall


### PR DESCRIPTION
Closes #92

Defines the typed NMU request/response control boundary with independent AW and AR admission lanes plus independent B and R retirement lanes. The contract carries AXI ID, burst length, SAM destination metadata, AXI class, ordering request/tag, and retirement last metadata. It adds only the interface, boundary shell, focused Verilator contract test, build registration, and trade-off record.

Verification: make clean; make rtl-nmu-ctrl-test; make clean. The contract linted at AXI_ID_WIDTH 1, 3, and 8 and the default simulation passed.