### PR TITLE
refactor(nmu): rename control shell to wrapper

### DIFF
--- a/rtl/Bender.yml
+++ b/rtl/Bender.yml
@@ -19,4 +19,4 @@ sources:
   - nmu/nmu_response_path.sv
   - nmu/nmu.sv
   - nmu/nmu_request_fifo.sv
-  - nmu/nmu_req_rsp_ctrl_shell.sv
+  - nmu/nmu_req_rsp_ctrl_wrap.sv

--- a/rtl/nmu/nmu_req_rsp_ctrl_wrap.sv
+++ b/rtl/nmu/nmu_req_rsp_ctrl_wrap.sv
@@ -4,8 +4,8 @@
 `timescale 1ns / 1ps
 `default_nettype none
 
-// Boundary-only shell. Storage and ordering policy belong to the next issue.
-module nmu_req_rsp_ctrl_shell #(
+// Boundary-only wrapper. Storage and ordering policy belong to the next issue.
+module nmu_req_rsp_ctrl_wrap #(
     parameter int unsigned AXI_ID_WIDTH = ni_params_pkg::AXI_ID_WIDTH_DFLT,
     parameter int unsigned MAX_TXNS_PER_ID = ni_params_pkg::NMU_MAX_TXNS_PER_ID_DFLT
 ) (

--- a/rtl/nmu/test_req_rsp_ctrl.sh
+++ b/rtl/nmu/test_req_rsp_ctrl.sh
@@ -9,7 +9,7 @@ task_sources=(
     "$task_root/specgen/generated/sv/ni_params_pkg.sv"
     "$task_root/specgen/generated/sv/ni_flit_pkg.sv"
     "$task_root/rtl/common/nmu_req_rsp_ctrl_if.sv"
-    "$task_root/rtl/nmu/nmu_req_rsp_ctrl_shell.sv"
+    "$task_root/rtl/nmu/nmu_req_rsp_ctrl_wrap.sv"
     "$task_root/rtl/nmu/tests/tb_nmu_req_rsp_ctrl.sv"
 )
 

--- a/rtl/nmu/tests/tb_nmu_req_rsp_ctrl.sv
+++ b/rtl/nmu/tests/tb_nmu_req_rsp_ctrl.sv
@@ -12,7 +12,7 @@ module tb_nmu_req_rsp_ctrl #(
         .MAX_TXNS_PER_ID ( MAX_TXNS_PER_ID )
     ) ctrl ();
 
-    nmu_req_rsp_ctrl_shell #(
+    nmu_req_rsp_ctrl_wrap #(
         .AXI_ID_WIDTH    ( AXI_ID_WIDTH ),
         .MAX_TXNS_PER_ID ( MAX_TXNS_PER_ID )
     ) dut ( .ctrl ( ctrl ) );


### PR DESCRIPTION
Renames the boundary-only nmu_req_rsp_ctrl_shell module and file to nmu_req_rsp_ctrl_wrap. No functional logic changes.\n\nVerification: make clean; make rtl-nmu-ctrl-test; make clean.