### PR TITLE
docs(nmu): reserve management interface directory

### DIFF
--- a/rtl/nmu/interfaces/README.md
+++ b/rtl/nmu/interfaces/README.md
@@ -1,0 +1,3 @@
+NMU-specific management interfaces belong in this directory.
+
+Do not add an interface until the request/response path contract is approved.


### PR DESCRIPTION
Adds the requested rtl/nmu/interfaces directory marker without inventing an interface before the request/response contract is approved.