### PR TITLE
fix(sim): per-VC wormhole arbitration and single-stage egress hold

### DIFF
--- a/ref_model/c_model/include/ni/wormhole_arbiter.hpp
+++ b/ref_model/c_model/include/ni/wormhole_arbiter.hpp
@@ -13,16 +13,27 @@
 //   NSU: Packetize{b,r} -> WormholeArbiter<NocRspOut>(2 in, {}) -> VcAllocator
 //        -> NocRspOut
 //
-// Lock semantic:
+// Lock semantic — PER VC (worm contiguity is a per-(link, VC) invariant;
+// cross-VC interleave on the shared link is what VCs exist for):
 //   * When a flit with header.flit_tail=0 (packet start, e.g., AW) is
-//     drained, lock to the SAME input by default (continue serving it across
-//     the worm -- covers a multi-flit worm pre-merged onto one input, e.g.
-//     wrap/dat_merge_wrap.hpp's NMU-side DataAw+DataW). A configured
-//     `pairing.from == this port` overrides the default and locks to
-//     `pairing.to` instead (the AW-port/W-port shape, e.g. nmu.hpp's req
-//     wormhole_arbiter_: AW on port 0 locks to W's port 1).
-//   * When a flit with header.flit_tail=1 (packet end, e.g., W with wlast) is
-//     drained from the currently locked port, unlock.
+//     drained, its header vc_id becomes OWNED by the same input by default
+//     (continue serving that worm's VC from it -- covers a multi-flit worm
+//     pre-merged onto one input, e.g. wrap/dat_merge_wrap.hpp's NMU-side
+//     DataAw+DataW). A configured `pairing.from == this port` overrides the
+//     default and hands the VC to `pairing.to` instead (the AW-port/W-port
+//     shape, e.g. nmu.hpp's req wormhole_arbiter_: AW on port 0 locks to
+//     W's port 1).
+//   * When a flit with header.flit_tail=1 (packet end, e.g., W with wlast)
+//     is drained on an owned VC, that VC is released. A tail on a DIFFERENT
+//     VC releases nothing -- an input that legally interleaves worms across
+//     VCs (nmu::VcAllocator's cross-VC round-robin drain) must not have one
+//     worm's tail unlock another worm's VC and let the other input's flit
+//     (NSU's single-flit DataR, hashed onto the same VC) split that worm
+//     (2026-08-21 uniform_random burst root cause).
+//   * An input whose front flit's VC is owned by ANOTHER input is skipped;
+//     fronts on unowned or self-owned VCs stay eligible.
+//   * With every flit on vc 0 (the single-VC faces: NMU REQ / DAT pre-merge,
+//     NSU RSP) this degenerates to the previous stream-level lock exactly.
 //   * Without pairing and flit_tail always 1 (NSU case: B/R are always
 //     single-flit worms), the lock branch never triggers; every flit is its
 //     own packet, matching the pre-existing behavior unchanged.
@@ -121,27 +132,30 @@ class WormholeArbiter {
         return input_adapters_[idx];
     }
 
-    void tick();
+    // One grant per tick. Returns the (input index, flit) actually drained, or
+    // nullopt when nothing drained — wrap/dat_merge_wrap.hpp attributes its
+    // per-VC credit-return pulse from this across a DPI boundary the arbiter
+    // has no visibility into.
+    std::optional<std::pair<std::size_t, Flit>> tick();
 
-    // Introspection (test + production use — see wrap/dat_merge_wrap.hpp,
-    // which peeks the about-to-drain flit's header to attribute a per-VC
-    // credit-return pulse correctly across a DPI boundary this arbiter has
-    // no visibility into).
+    // Introspection: total pending flits for input idx, summed across VCs.
     std::size_t pending_size(std::size_t idx) const {
         assert(idx < num_inputs_);
-        return pending_[idx].size();
+        std::size_t total = 0;
+        for (const auto& q : pending_[idx]) total += q.size();
+        return total;
     }
-    bool is_locked() const noexcept { return locked_to_.has_value(); }
-    std::optional<std::size_t> locked_to() const noexcept { return locked_to_; }
-    // Front flit of input idx's pending queue, or nullopt if empty. Read-only
-    // peek — does not affect tick()'s target selection or lock state.
-    std::optional<Flit> peek(std::size_t idx) const {
-        assert(idx < num_inputs_);
-        if (pending_[idx].empty()) return std::nullopt;
-        return pending_[idx].front();
-    }
+    bool is_locked(uint8_t vc = 0) const noexcept { return vc_owner_[vc].has_value(); }
+    std::optional<std::size_t> locked_to(uint8_t vc = 0) const noexcept { return vc_owner_[vc]; }
 
   private:
+    // Per (input, VC) pending queues. One shared queue per input would let a
+    // front flit blocked on ITS VC's downstream credit hold every other VC's
+    // flits behind it — with the DAT router's whole-output wormhole lock on
+    // the other side of that credit loop, exactly the cross-VC cycle that
+    // deadlocked mode-1 co-sim (2026-08-21). VCs are independently
+    // flow-controlled end to end everywhere else (per-VC credit, per-VC
+    // router FIFOs, per-VC NI allocator queues); this stage matches.
     struct InputAdapter : Downstream {
         WormholeArbiter* parent;
         std::size_t idx;
@@ -149,14 +163,18 @@ class WormholeArbiter {
         InputAdapter(WormholeArbiter* p, std::size_t i) : parent(p), idx(i) {}
 
         bool push_flit(const Flit& f) override {
-            if (parent->pending_[idx].size() >= parent->per_input_depth_) return false;
-            parent->pending_[idx].push_back(f);
+            const auto vc = static_cast<uint8_t>(f.get_header_field("vc_id"));
+            auto& q = parent->pending_[idx][vc];
+            if (q.size() >= parent->per_input_depth_) return false;
+            q.push_back(f);
             return true;
         }
-        bool credit_avail(uint8_t /*vc_id*/) const override {
-            return parent->pending_[idx].size() < parent->per_input_depth_;
+        bool credit_avail(uint8_t vc_id) const override {
+            return parent->pending_[idx][vc_id].size() < parent->per_input_depth_;
         }
     };
+
+    bool try_grant_(std::size_t target, uint8_t vc);
 
     bool is_from_port(std::size_t idx) const {
         for (const auto& p : pairings_)
@@ -169,37 +187,85 @@ class WormholeArbiter {
         return false;
     }
 
+    // Worm ownership per VC (vc_id is a 3 b header field): which input, if
+    // any, holds this VC mid-worm. nullopt = free.
+    static constexpr std::size_t kNumVcSlots = 1u << ni::header::VC_ID_WIDTH;
+
     Downstream& downstream_;
     std::size_t num_inputs_;
     std::vector<ChannelPairing> pairings_;
-    std::size_t per_input_depth_;
-    std::vector<std::deque<Flit>> pending_;
+    std::size_t per_input_depth_;  // per (input, VC) queue depth
+    std::vector<std::array<std::deque<Flit>, kNumVcSlots>> pending_;
     std::vector<InputAdapter> input_adapters_;
     std::size_t round_robin_ptr_ = 0;
-    std::optional<std::size_t> locked_to_;
+    std::size_t vc_rr_ = 0;  // VC scan start, advanced with each grant
+    std::array<std::optional<std::size_t>, kNumVcSlots> vc_owner_{};
+    Flit drained_flit_;  // last granted flit, copied out by tick()
 };
 
 template <typename Downstream>
-inline void WormholeArbiter<Downstream>::tick() {
-    std::size_t target;
-
-    if (locked_to_.has_value()) {
-        target = *locked_to_;
-        if (pending_[target].empty()) return;
-    } else {
-        bool found = false;
-        for (std::size_t k = 0; k < num_inputs_; ++k) {
-            std::size_t i = (round_robin_ptr_ + k) % num_inputs_;
-            if (!pending_[i].empty()) {
-                target = i;
-                found = true;
-                break;
+inline std::optional<std::pair<std::size_t, Flit>> WormholeArbiter<Downstream>::tick() {
+    // Eligibility scan (per-VC lock, see file header) over (input, VC) queue
+    // fronts, round-robin over both dimensions. A front is skipped when its
+    // VC is mid-worm from ANOTHER input. A candidate whose downstream push
+    // is refused (per-VC credit, queue full) is skipped too and the scan
+    // CONTINUES — giving up on the first refused candidate would retry it
+    // forever (round-robin only advances on a grant) while a grantable
+    // candidate starves behind it; with the refused VC's credit waiting on
+    // fabric progress that needs the starved candidate, that is the mode-1
+    // livelock the 2026-08-21 watchdog dump caught. At most one grant per
+    // tick either way.
+    std::size_t target = 0;
+    uint8_t vc = 0;
+    bool granted = false;
+    for (std::size_t k = 0; k < num_inputs_ && !granted; ++k) {
+        const std::size_t i = (round_robin_ptr_ + k) % num_inputs_;
+        for (std::size_t kv = 0; kv < kNumVcSlots; ++kv) {
+            const auto v = static_cast<uint8_t>((vc_rr_ + kv) % kNumVcSlots);
+            if (pending_[i][v].empty()) continue;
+            if (vc_owner_[v].has_value() && *vc_owner_[v] != i) continue;
+            // A to-port (paired W) front is a candidate only once its AW's
+            // grant handed it the VC: an AW refused downstream leaves the VC
+            // unowned, and the work-conserving scan must step PAST its W --
+            // but only while that AW is actually queued. A W with no AW
+            // anywhere is broken upstream serialization; parking it silently
+            // would trade the old loud abort for a wedge.
+            if (is_to_port(i) && !vc_owner_[v].has_value()) {
+                bool aw_queued = false;
+                for (const auto& p : pairings_) {
+                    if (p.to == i && !pending_[p.from][v].empty()) {
+                        aw_queued = true;
+                        break;
+                    }
+                }
+                if (!aw_queued) {
+                    assert(false &&
+                           "WormholeArbiter::tick: to-port flit pending with no from-port flit "
+                           "queued and no VC ownership (W before AW; upstream serialization "
+                           "broken)");
+                    std::abort();
+                }
+                continue;
             }
+            target = i;
+            vc = v;
+            granted = try_grant_(target, vc);
+            if (granted) break;
         }
-        if (!found) return;
     }
+    if (!granted) return std::nullopt;
 
-    const Flit& flit = pending_[target].front();
+    const std::pair<std::size_t, Flit> drained{target, drained_flit_};
+    return drained;
+}
+
+// One candidate attempt: protocol guards, downstream push, and on success the
+// pop + round-robin + per-VC ownership bookkeeping. Returns false on a
+// downstream refusal (legitimate backpressure, req_out.hpp: "a false return
+// MUST be safely retried") so tick()'s scan can move to the next candidate.
+template <typename Downstream>
+inline bool WormholeArbiter<Downstream>::try_grant_(std::size_t target, uint8_t vc) {
+    const Flit& flit = pending_[target][vc].front();
     uint64_t flit_tail = flit.get_header_field("flit_tail");
 
     // Defensive guards (header.flit_tail stamping invariant)
@@ -209,47 +275,43 @@ inline void WormholeArbiter<Downstream>::tick() {
                "Packetize must stamp header.flit_tail=0 on AW");
         std::abort();
     }
-    if (is_to_port(target) && !locked_to_.has_value()) {
+    if (is_to_port(target) && !vc_owner_[vc].has_value()) {
         assert(false &&
                "WormholeArbiter::tick: to-port flit pushed without preceding from-port flit (W "
                "before AW; upstream serialization broken)");
         std::abort();
     }
 
-    // Pure valid/ready handshake: this arbiter only selects one request out of
-    // the input queues toward the NoC -- it does not decide VC or track credit.
-    // VC selection and per-VC credit gating live entirely in the downstream
-    // nmu::VcAllocator. A false return is legitimate backpressure (req_out.hpp:
-    // "a false return MUST be safely retried"), so retain the front flit and
-    // retry next tick. Mirrors FlooNoC floo_wormhole_arbiter.sv, a pure
-    // handshake with no credit logic.
-    if (!downstream_.push_flit(flit)) return;
+    // Pure valid/ready handshake toward the downstream (VC selection and
+    // credit gating live there). Refusal -> false, the flit stays queued.
+    if (!downstream_.push_flit(flit)) return false;
 
-    pending_[target].pop_front();
+    drained_flit_ = flit;
+    pending_[target][vc].pop_front();
     round_robin_ptr_ = (target + 1) % num_inputs_;
+    vc_rr_ = (static_cast<std::size_t>(vc) + 1) % kNumVcSlots;
 
-    // Lock/unlock transition. Default: lock to SELF (continue serving the
-    // same input across the worm) -- covers a multi-flit worm arriving on
-    // one already-merged input (S3a T5 DatMergeWrap: NMU's DataAw+DataW
-    // arrive sequentially on ONE input, not two ports to pair). An explicit
-    // ChannelPairing overrides this to lock a DIFFERENT port instead (the
-    // AW-port/W-port shape, e.g. nmu.hpp's req wormhole_arbiter_). Router's/
-    // SimpleRouter's own inline per-output lock is exactly this same
-    // self-lock rule with no pairing concept at all; this generalizes
-    // WormholeArbiter to the same default instead of adding a second
-    // implementation of it.
-    if (flit_tail == 0 && !locked_to_.has_value()) {
-        locked_to_ = target;
+    // Ownership transition, per VC. Default: the worm's VC stays with SELF
+    // (continue serving the same input across the worm) -- covers a
+    // multi-flit worm arriving on one already-merged input (S3a T5
+    // DatMergeWrap: NMU's DataAw+DataW arrive sequentially on ONE input, not
+    // two ports to pair). An explicit ChannelPairing hands the VC to a
+    // DIFFERENT port instead (the AW-port/W-port shape, e.g. nmu.hpp's req
+    // wormhole_arbiter_). A tail releases only ITS OWN VC -- another worm's
+    // tail from the same input must not (file header, per-VC rule).
+    if (flit_tail == 0 && !vc_owner_[vc].has_value()) {
+        vc_owner_[vc] = target;
         for (const auto& p : pairings_) {
             if (p.from == target) {
-                locked_to_ = p.to;
+                vc_owner_[vc] = p.to;
                 break;
             }
         }
-    } else if (flit_tail == 1 && locked_to_.has_value()) {
-        assert(*locked_to_ == target && "WormholeArbiter::tick: unlock target mismatch");
-        locked_to_ = std::nullopt;
+    } else if (flit_tail == 1 && vc_owner_[vc].has_value()) {
+        assert(*vc_owner_[vc] == target && "WormholeArbiter::tick: unlock target mismatch");
+        vc_owner_[vc] = std::nullopt;
     }
+    return true;
 }
 
 }  // namespace ni::cmodel::router

--- a/ref_model/c_model/include/wrap/dat_merge_wrap.hpp
+++ b/ref_model/c_model/include/wrap/dat_merge_wrap.hpp
@@ -23,12 +23,14 @@
 //
 // Egress mux (NMU input 0 / NSU input 1 -> router): router::WormholeArbiter,
 // the existing translated floo_wormhole_arbiter port (ni/wormhole_arbiter.hpp)
-// -- NOT a new arbiter. No ChannelPairing: each input is already a
-// fully-formed, worm-locked stream (NMU's own dat_wormhole_arbiter_ already
-// pairs DataAw with its DataW, exactly the chimney's SelAw/SelW-muxed
-// WideAw/W stream; NSU's DataR is single-flit, needs no pairing) -- this is
-// structurally identical to nsu.hpp's own RSP-egress wormhole_arbiter_ (2
-// inputs, no pairing, each already a complete stream). ONE shared credit pool
+// -- NOT a new arbiter. No ChannelPairing: NMU's own dat_wormhole_arbiter_
+// already pairs DataAw with its DataW (the chimney's SelAw/SelW-muxed
+// WideAw/W stream) and NSU's DataR is single-flit. The NMU input is NOT one
+// worm-locked stream, though: nmu::VcAllocator's cross-VC round-robin drain
+// legally interleaves worms ACROSS VCs (each VC's stream stays contiguous),
+// which is exactly why the arbiter's locking is per VC -- a stream-level
+// lock here once let one worm's tail release another VC's mid-flight worm
+// and admit NSU's DataR into its beat stream (2026-08-21). ONE shared credit pool
 // downstream of the arbiter (DatMergeDownstream, term_ below), sized to the
 // DAT router's real LOCAL input depth (NOC_ROUTER_VC_DEPTH) -- replaces NMU's
 // and NSU's previous independent full-depth pools (the inconsistency the
@@ -130,16 +132,12 @@ class DatMergeWrap {
     void init(uint8_t dat_num_vc) {
         dat_num_vc_ = dat_num_vc;
         term_.enable_credit(dat_num_vc, static_cast<std::size_t>(::ni::NOC_ROUTER_VC_DEPTH));
-        // Per-input pending depth pools credit across all dat_num_vc virtual
-        // channels: the WormholeArbiter pending stage has no VC dimension
-        // (ponytail: the real per-VC gate is term_, downstream; sizing this
-        // stage per-VC too would need a VC-aware arbiter variant nothing else
-        // in this codebase has). Sized to the larger of NMU's/NSU's own
-        // per-VC arbiter-stage depth (times dat_num_vc) so neither side's
-        // unchanged per-VC sender credit can ever outrun this stage's
-        // capacity -- see the push_flit asserts in tick().
+        // WormholeArbiter pending is per (input, VC); this depth is the
+        // per-(input, VC) queue depth. Sized to the larger of NMU's/NSU's own
+        // per-VC arbiter-stage depth so neither side's unchanged per-VC
+        // sender credit can ever outrun this stage's capacity -- see the
+        // push_flit asserts in tick().
         const std::size_t per_input_depth =
-            static_cast<std::size_t>(dat_num_vc) *
             std::max<std::size_t>(static_cast<std::size_t>(::ni::NMU_ARBITER_FIFO_DEPTH),
                                   static_cast<std::size_t>(::ni::NSU_ARBITER_FIFO_DEPTH));
         wormhole_ = std::make_unique<router::WormholeArbiter<detail::DatMergeDownstream>>(
@@ -177,25 +175,19 @@ class DatMergeWrap {
             if (in_.tx_dat_crdvalid[vc]) term_.receive_credit(vc);
         }
 
-        // Snapshot each input's about-to-drain flit (for per-VC credit-return
-        // attribution -- the arbiter itself tracks no VC dimension) and
-        // occupancy (to detect which input, if any, actually drained).
-        const auto peek0 = wormhole_->peek(0);
-        const auto peek1 = wormhole_->peek(1);
-        const std::size_t before0 = wormhole_->pending_size(0);
-        const std::size_t before1 = wormhole_->pending_size(1);
-
-        // Step 2: advance the arbiter (at most one input drains into term_
-        // this tick -- WormholeArbiter::tick() makes a single grant decision).
-        wormhole_->tick();
+        // Step 2: advance the arbiter (at most one grant per tick); the
+        // returned (input, flit) attributes the per-VC credit-return pulse.
+        const auto drained = wormhole_->tick();
 
         out_ = DatMergeOutputs{};
 
-        if (peek0 && wormhole_->pending_size(0) < before0) {
-            out_.nmu_tx_dat_crdvalid[static_cast<uint8_t>(peek0->get_header_field("vc_id"))] = true;
-        }
-        if (peek1 && wormhole_->pending_size(1) < before1) {
-            out_.nsu_tx_dat_crdvalid[static_cast<uint8_t>(peek1->get_header_field("vc_id"))] = true;
+        if (drained.has_value()) {
+            const auto vc = static_cast<uint8_t>(drained->second.get_header_field("vc_id"));
+            if (drained->first == 0) {
+                out_.nmu_tx_dat_crdvalid[vc] = true;
+            } else {
+                out_.nsu_tx_dat_crdvalid[vc] = true;
+            }
         }
 
         // Step 3: drain the shared downstream pool toward the router.

--- a/ref_model/c_model/tests/router/test_wormhole_arbiter.cpp
+++ b/ref_model/c_model/tests/router/test_wormhole_arbiter.cpp
@@ -206,6 +206,132 @@ TEST(NocWormholeArbiter, LockLeakIdleStallNoDeadlock) {
     EXPECT_TRUE(arb.is_locked());
 }
 
+// Per-VC ownership (DatMergeWrap bug, 2026-08-21): input 0 legally interleaves
+// two worms ACROSS VCs (per-VC each stream is contiguous). The vc1 worm's tail
+// must release vc1 only -- vc0 stays owned by input 0 until ITS tail, so input
+// 1's vc0 single-flit packet cannot slip between the vc0 worm's beats.
+TEST(NocWormholeArbiter, PerVcLockSurvivesOtherVcTail) {
+    ReqCapture down;
+    WormholeArbiter<ni::cmodel::router::NocReqOut> arb(down, /*num_inputs=*/2, {});
+
+    auto vc_flit = [](uint8_t vc, uint64_t flit_tail, uint64_t marker) {
+        Flit f = make_flit(ni::AXI_CH_DataAw, flit_tail);
+        f.set_header_field("vc_id", vc);
+        f.set_header_field("dst_id", marker);
+        return f;
+    };
+    // input 0: vc0 worm head, then a complete vc1 worm; the vc0 tail comes later.
+    ASSERT_TRUE(arb.input(0).push_flit(vc_flit(0, /*flit_tail=*/0, 10)));
+    ASSERT_TRUE(arb.input(0).push_flit(vc_flit(1, /*flit_tail=*/0, 20)));
+    ASSERT_TRUE(arb.input(0).push_flit(vc_flit(1, /*flit_tail=*/1, 21)));
+    // input 1: single-flit packet on vc0 (the NSU DataR shape).
+    ASSERT_TRUE(arb.input(1).push_flit(vc_flit(0, /*flit_tail=*/1, 90)));
+
+    for (int i = 0; i < 3; ++i) arb.tick();  // drains input 0's three flits
+    EXPECT_EQ(down.size(), 3u);
+
+    arb.tick();  // vc0 still owned by input 0 (its tail not seen) -> input 1 waits
+    EXPECT_EQ(down.size(), 3u) << "vc1 tail must not release input 0's vc0 worm";
+    EXPECT_EQ(arb.pending_size(1), 1u);
+
+    ASSERT_TRUE(arb.input(0).push_flit(vc_flit(0, /*flit_tail=*/1, 11)));  // vc0 tail
+    arb.tick();                                                            // vc0 worm completes
+    arb.tick();  // now input 1's vc0 flit may drain
+    EXPECT_EQ(down.size(), 5u);
+    for (uint64_t marker : {10u, 20u, 21u, 11u, 90u}) {
+        auto f = down.pop();
+        ASSERT_TRUE(f.has_value());
+        EXPECT_EQ(f->get_header_field("dst_id"), marker);
+    }
+}
+
+// Cross-VC interleave stays legal: while input 0 owns vc0 mid-worm, input 1's
+// flit on a DIFFERENT vc passes -- worm contiguity is per (link, VC), not per
+// link (VCs exist to interleave).
+TEST(NocWormholeArbiter, OtherVcPassesWhileVcLocked) {
+    ReqCapture down;
+    WormholeArbiter<ni::cmodel::router::NocReqOut> arb(down, /*num_inputs=*/2, {});
+
+    auto vc_flit = [](uint8_t vc, uint64_t flit_tail, uint64_t marker) {
+        Flit f = make_flit(ni::AXI_CH_DataAw, flit_tail);
+        f.set_header_field("vc_id", vc);
+        f.set_header_field("dst_id", marker);
+        return f;
+    };
+    ASSERT_TRUE(arb.input(0).push_flit(vc_flit(0, /*flit_tail=*/0, 10)));  // vc0 worm head
+    ASSERT_TRUE(arb.input(1).push_flit(vc_flit(2, /*flit_tail=*/1, 92)));  // other-vc single
+
+    arb.tick();  // vc0 head drains, vc0 owned by input 0
+    arb.tick();  // input 0 empty; input 1's vc2 flit is NOT blocked by the vc0 lock
+    EXPECT_EQ(down.size(), 2u);
+    EXPECT_EQ(arb.pending_size(1), 0u);
+}
+
+// Per-(input, VC) queues: a front flit blocked on ITS VC's downstream credit
+// must not hold another VC's flits behind it -- the cross-VC head-of-line
+// that closed the 2026-08-21 mode-1 deadlock cycle (merge front blocked on
+// vc1 credit, vc1 credit waiting on a router output locked by a vc0 worm
+// whose tail sat behind that front).
+TEST(NocWormholeArbiter, BlockedVcDoesNotHeadOfLineBlockOtherVc) {
+    struct Vc1Refuser : ni::cmodel::router::NocReqOut {
+        std::vector<Flit> accepted;
+        bool push_flit(const Flit& f) override {
+            if (f.get_header_field("vc_id") == 1) return false;
+            accepted.push_back(f);
+            return true;
+        }
+        bool credit_avail(uint8_t vc_id) const override { return vc_id != 1; }
+    } down;
+    WormholeArbiter<ni::cmodel::router::NocReqOut> arb(down, /*num_inputs=*/1, {});
+
+    Flit blocked = make_flit(ni::AXI_CH_DataAw, /*flit_tail=*/1);
+    blocked.set_header_field("vc_id", 1);
+    Flit ok = make_flit(ni::AXI_CH_DataAw, /*flit_tail=*/1);
+    ok.set_header_field("vc_id", 0);
+    ASSERT_TRUE(arb.input(0).push_flit(blocked));  // pushed first
+    ASSERT_TRUE(arb.input(0).push_flit(ok));
+
+    arb.tick();
+    arb.tick();
+    ASSERT_EQ(down.accepted.size(), 1u) << "vc0 flit must drain despite blocked vc1 front";
+    EXPECT_EQ(down.accepted[0].get_header_field("vc_id"), 0u);
+    EXPECT_EQ(arb.pending_size(0), 1u);  // the vc1 flit stays, retried
+}
+
+// Work-conserving scan: a candidate refused by the downstream (per-VC credit)
+// must not end the tick -- the scan moves on and grants the next eligible
+// candidate. Giving up on the first refusal retries it forever (round-robin
+// advances only on grant) and starves the grantable input: the 2026-08-21
+// mode-1 livelock (merge stuck on a credit-blocked NSU vc1 front while the
+// NMU vc0 worm the fabric was waiting for sat ungranted).
+TEST(NocWormholeArbiter, RefusedCandidateDoesNotStarveGrantableOne) {
+    struct Vc1Refuser : ni::cmodel::router::NocReqOut {
+        std::vector<Flit> accepted;
+        bool push_flit(const Flit& f) override {
+            if (f.get_header_field("vc_id") == 1) return false;
+            accepted.push_back(f);
+            return true;
+        }
+        bool credit_avail(uint8_t vc_id) const override { return vc_id != 1; }
+    } down;
+    WormholeArbiter<ni::cmodel::router::NocReqOut> arb(down, /*num_inputs=*/2, {});
+
+    Flit blocked = make_flit(ni::AXI_CH_DataAw, /*flit_tail=*/1);
+    blocked.set_header_field("vc_id", 1);
+    Flit ok = make_flit(ni::AXI_CH_DataAw, /*flit_tail=*/1);
+    ok.set_header_field("vc_id", 0);
+    // Round-robin starts at input 0, whose only front is the refused vc1 flit.
+    ASSERT_TRUE(arb.input(0).push_flit(blocked));
+    ASSERT_TRUE(arb.input(1).push_flit(ok));
+
+    arb.tick();
+    ASSERT_EQ(down.accepted.size(), 1u)
+        << "input 1's grantable vc0 flit must drain in the same tick the "
+           "refused vc1 candidate was skipped";
+    EXPECT_EQ(down.accepted[0].get_header_field("vc_id"), 0u);
+    EXPECT_EQ(arb.pending_size(0), 1u);  // refused flit stays, retried later
+}
+
 // ---- Death tests (3) ----
 
 TEST(NocWormholeArbiterDeath, WBeforeAW) {

--- a/ref_model/top/nmu_wrap.sv
+++ b/ref_model/top/nmu_wrap.sv
@@ -167,7 +167,6 @@ module nmu_wrap #(
     bit                    tx_req_valid_q;
     bit [REQ_FLIT_WIDTH-1:0] tx_req_flit_q;
     logic                  tx_req_model_ready;
-    logic                  tx_req_spill_ready;
     bit                    rx_rsp_ready_q;
     bit                    tx_dat_valid_q;
     bit [DAT_FLIT_WIDTH-1:0] tx_dat_flit_q;
@@ -281,8 +280,16 @@ module nmu_wrap #(
                 rdata_q                 <= t_rdata;
                 rresp_q                 <= t_rresp;
                 rlast_q                 <= t_rlast;
-                tx_req_valid_q          <= t_tx_req_valid;
-                tx_req_flit_q           <= t_tx_req_flit;
+                // REQ egress hold register: the strobe loads it, the wire
+                // handshake frees it; a strobe may land on the freeing edge
+                // (load wins, the old flit was consumed at that edge). See
+                // router_wrap.sv's identical staging.
+                if (t_tx_req_valid) begin
+                    tx_req_valid_q <= 1'b1;
+                    tx_req_flit_q  <= t_tx_req_flit;
+                end else if (tx_req_ready_i) begin
+                    tx_req_valid_q <= 1'b0;
+                end
                 rx_rsp_ready_q          <= t_rx_rsp_ready;
                 tx_dat_valid_q          <= t_tx_dat_valid;
                 tx_dat_flit_q           <= t_tx_dat_flit;
@@ -310,30 +317,27 @@ module nmu_wrap #(
     assign axi_rsp_o.rresp   = rresp_q;
     assign axi_rsp_o.rlast   = rlast_q;
 
-    // The C++ model emits a one-cycle REQ strobe after sampling ready.  The
-    // existing DPI output register is one cycle ahead of the spill register,
-    // so stop another model pop while that register carries an unaccepted
-    // pulse.  The spill register then owns the RTL-facing held-valid contract.
-    assign tx_req_model_ready = tx_req_spill_ready && !tx_req_valid_q;
+    // The C++ model emits a one-cycle REQ strobe after sampling ready; the
+    // hold register above owns the RTL-facing held-valid contract, and the
+    // model may pop when it is empty or its flit's handshake completes this
+    // cycle (full rate, single stage).
+    assign tx_req_model_ready = !tx_req_valid_q || tx_req_ready_i;
+    assign tx_req_valid_o = tx_req_valid_q;
+    assign tx_req_flit_o  = tx_req_flit_q;
 
-    spill_register #(
-        .T(logic [REQ_FLIT_WIDTH-1:0]),
-        .Bypass(1'b0)
-    ) i_tx_req_spill_register (
-        .clk_i,
-        .rst_ni,
-        .valid_i(tx_req_valid_q),
-        .ready_o(tx_req_spill_ready),
-        .data_i(tx_req_flit_q),
-        .valid_o(tx_req_valid_o),
-        .ready_i(tx_req_ready_i),
-        .data_o(tx_req_flit_o)
-    );
-
-    assert property (@(posedge clk_i) disable iff (!rst_ni)
-        tx_req_valid_o && !tx_req_ready_i
-        |=> tx_req_valid_o && $stable(tx_req_flit_o))
-        else $error("nmu_wrap: REQ changed before valid/ready handshake");
+    // Egress-hold checker, explicit sampled-history form (SVA $stable in a
+    // |=> consequent false-fires under Verilator on the first backpressured
+    // cycle — see router_wrap.sv).
+    logic chk_req_v_q, chk_req_r_q;
+    logic [REQ_FLIT_WIDTH-1:0] chk_req_flit_q;
+    always_ff @(posedge clk_i) begin
+        chk_req_v_q    <= rst_ni && tx_req_valid_o;
+        chk_req_r_q    <= tx_req_ready_i;
+        chk_req_flit_q <= tx_req_flit_o;
+        if (rst_ni && chk_req_v_q && !chk_req_r_q &&
+            (!tx_req_valid_o || tx_req_flit_o !== chk_req_flit_q))
+            $error("nmu_wrap: REQ changed before valid/ready handshake");
+    end
 
     assign rx_rsp_ready_o    = rx_rsp_ready_q;
     assign tx_dat_valid_o    = tx_dat_valid_q;

--- a/ref_model/top/nsu_wrap.sv
+++ b/ref_model/top/nsu_wrap.sv
@@ -145,7 +145,6 @@ module nsu_wrap #(
     bit                    tx_rsp_valid_q;
     bit [RSP_FLIT_WIDTH-1:0] tx_rsp_flit_q;
     logic                  tx_rsp_model_ready;
-    logic                  tx_rsp_spill_ready;
     bit                    tx_dat_valid_q;
     bit [DAT_FLIT_WIDTH-1:0] tx_dat_flit_q;
     bit [DAT_NUM_VC-1:0]     rx_dat_crdvalid_q;
@@ -298,8 +297,16 @@ module nsu_wrap #(
                     t_rready
                 );
                 rx_req_ready_q          <= t_rx_req_ready;
-                tx_rsp_valid_q          <= t_tx_rsp_valid;
-                tx_rsp_flit_q           <= t_tx_rsp_flit;
+                // RSP egress hold register: the strobe loads it, the wire
+                // handshake frees it; a strobe may land on the freeing edge
+                // (load wins, the old flit was consumed at that edge). See
+                // router_wrap.sv's identical staging.
+                if (t_tx_rsp_valid) begin
+                    tx_rsp_valid_q <= 1'b1;
+                    tx_rsp_flit_q  <= t_tx_rsp_flit;
+                end else if (tx_rsp_ready_i) begin
+                    tx_rsp_valid_q <= 1'b0;
+                end
                 tx_dat_valid_q          <= t_tx_dat_valid;
                 tx_dat_flit_q           <= t_tx_dat_flit;
                 rx_dat_crdvalid_q       <= t_rx_dat_crdvalid;
@@ -338,29 +345,27 @@ module nsu_wrap #(
     // -------------------------------------------------------------------------
 
     assign rx_req_ready_o    = rx_req_ready_q;
-    // Match the one-cycle C++ response strobe to the RTL-side held-valid
-    // contract.  Do not allow another model pop while the DPI staging register
-    // still holds a pulse that the spill register has not sampled.
-    assign tx_rsp_model_ready = tx_rsp_spill_ready && !tx_rsp_valid_q;
+    // The C++ model emits a one-cycle RSP strobe after sampling ready; the
+    // hold register above owns the RTL-facing held-valid contract, and the
+    // model may pop when it is empty or its flit's handshake completes this
+    // cycle (full rate, single stage).
+    assign tx_rsp_model_ready = !tx_rsp_valid_q || tx_rsp_ready_i;
+    assign tx_rsp_valid_o = tx_rsp_valid_q;
+    assign tx_rsp_flit_o  = tx_rsp_flit_q;
 
-    spill_register #(
-        .T(logic [RSP_FLIT_WIDTH-1:0]),
-        .Bypass(1'b0)
-    ) i_tx_rsp_spill_register (
-        .clk_i,
-        .rst_ni,
-        .valid_i(tx_rsp_valid_q),
-        .ready_o(tx_rsp_spill_ready),
-        .data_i(tx_rsp_flit_q),
-        .valid_o(tx_rsp_valid_o),
-        .ready_i(tx_rsp_ready_i),
-        .data_o(tx_rsp_flit_o)
-    );
-
-    assert property (@(posedge clk_i) disable iff (!rst_ni)
-        tx_rsp_valid_o && !tx_rsp_ready_i
-        |=> tx_rsp_valid_o && $stable(tx_rsp_flit_o))
-        else $error("nsu_wrap: RSP changed before valid/ready handshake");
+    // Egress-hold checker, explicit sampled-history form (SVA $stable in a
+    // |=> consequent false-fires under Verilator on the first backpressured
+    // cycle — see router_wrap.sv).
+    logic chk_rsp_v_q, chk_rsp_r_q;
+    logic [RSP_FLIT_WIDTH-1:0] chk_rsp_flit_q;
+    always_ff @(posedge clk_i) begin
+        chk_rsp_v_q    <= rst_ni && tx_rsp_valid_o;
+        chk_rsp_r_q    <= tx_rsp_ready_i;
+        chk_rsp_flit_q <= tx_rsp_flit_o;
+        if (rst_ni && chk_rsp_v_q && !chk_rsp_r_q &&
+            (!tx_rsp_valid_o || tx_rsp_flit_o !== chk_rsp_flit_q))
+            $error("nsu_wrap: RSP changed before valid/ready handshake");
+    end
 
     assign tx_dat_valid_o    = tx_dat_valid_q;
     assign tx_dat_flit_o     = tx_dat_flit_q;

--- a/ref_model/top/router_wrap.sv
+++ b/ref_model/top/router_wrap.sv
@@ -158,12 +158,10 @@ module router_wrap #(
     bit [LINK_PORTS-1:0]     tx_req_valid_q;
     logic [REQ_FLIT_WIDTH-1:0] tx_req_flit_q [LINK_PORTS];
     logic [LINK_PORTS-1:0]     tx_req_model_ready;
-    logic [LINK_PORTS-1:0]     tx_req_spill_ready;
     bit [LINK_PORTS-1:0]     rx_req_ready_q;
     bit [LINK_PORTS-1:0]     tx_rsp_valid_q;
     logic [RSP_FLIT_WIDTH-1:0] tx_rsp_flit_q [LINK_PORTS];
     logic [LINK_PORTS-1:0]     tx_rsp_model_ready;
-    logic [LINK_PORTS-1:0]     tx_rsp_spill_ready;
     bit [LINK_PORTS-1:0]     rx_rsp_ready_q;
     bit [LINK_PORTS-1:0]     tx_dat_valid_q;
     logic [DAT_FLIT_WIDTH-1:0] tx_dat_flit_q [LINK_PORTS];
@@ -234,18 +232,34 @@ module router_wrap #(
                 cmodel_router_req_get_outputs(ctx_i, t_tx_req_valid, t_tx_req_flit, t_rx_req_ready);
                 cmodel_router_rsp_get_outputs(ctx_i, t_tx_rsp_valid, t_tx_rsp_flit, t_rx_rsp_ready);
                 cmodel_router_dat_get_outputs(ctx_i, t_tx_dat_valid, t_tx_dat_flit, t_rx_dat_crdvalid);
-                tx_req_valid_q <= t_tx_req_valid;
                 rx_req_ready_q <= t_rx_req_ready;
-                tx_rsp_valid_q <= t_tx_rsp_valid;
                 rx_rsp_ready_q <= t_rx_rsp_ready;
                 tx_dat_valid_q <= t_tx_dat_valid;
+                // REQ/RSP egress: the model strobe lands in a single HOLD
+                // register that keeps valid/flit until the wire handshake
+                // completes. A strobe may land on the same edge the previous
+                // flit's handshake frees the register (load wins; the old flit
+                // was consumed at this edge), which is what tx_*_model_ready's
+                // empty-or-draining condition guarantees. DAT stays a plain
+                // registered strobe (credit-gated, never backpressured).
+                //
                 // Unpacked arrays: bit temp -> logic reg element-wise. 5.048
                 // enforces IEEE 1800-2023 6.22.2 element-type equivalence on
                 // whole unpacked-array assigns; per-port packed 2->4 state
                 // stays legal.
                 for (int p = 0; p < LINK_PORTS; p++) begin
-                    tx_req_flit_q[p]     <= t_tx_req_flit[p];
-                    tx_rsp_flit_q[p]     <= t_tx_rsp_flit[p];
+                    if (t_tx_req_valid[p]) begin
+                        tx_req_valid_q[p] <= 1'b1;
+                        tx_req_flit_q[p]  <= t_tx_req_flit[p];
+                    end else if (tx_req_ready[p]) begin
+                        tx_req_valid_q[p] <= 1'b0;
+                    end
+                    if (t_tx_rsp_valid[p]) begin
+                        tx_rsp_valid_q[p] <= 1'b1;
+                        tx_rsp_flit_q[p]  <= t_tx_rsp_flit[p];
+                    end else if (tx_rsp_ready[p]) begin
+                        tx_rsp_valid_q[p] <= 1'b0;
+                    end
                     tx_dat_flit_q[p]     <= t_tx_dat_flit[p];
                     rx_dat_crdvalid_q[p] <= t_rx_dat_crdvalid[p];
                 end
@@ -261,55 +275,43 @@ module router_wrap #(
 
     assign rx_rsp_ready    = rx_rsp_ready_q;
 
-    for (genvar p = 0; p < LINK_PORTS; p++) begin : g_model_egress_spill
-        logic [REQ_FLIT_WIDTH-1:0] tx_req_flit_monitor;
-        logic [RSP_FLIT_WIDTH-1:0] tx_rsp_flit_monitor;
+    for (genvar p = 0; p < LINK_PORTS; p++) begin : g_model_egress_hold
+        // Each C++ router output is a one-cycle strobe; the hold register in
+        // the always_ff above owns the RTL-facing held-valid contract. The
+        // model may pop when the register is empty OR its flit's handshake
+        // completes this cycle (the free and the new load coincide on the
+        // next edge), which keeps the link at full rate with a single stage.
+        assign tx_req_model_ready[p] = !tx_req_valid_q[p] || tx_req_ready[p];
+        assign tx_rsp_model_ready[p] = !tx_rsp_valid_q[p] || tx_rsp_ready[p];
+        assign tx_req_valid[p] = tx_req_valid_q[p];
+        assign tx_req_flit[p]  = tx_req_flit_q[p];
+        assign tx_rsp_valid[p] = tx_rsp_valid_q[p];
+        assign tx_rsp_flit[p]  = tx_rsp_flit_q[p];
 
-        // Each C++ router output is a one-cycle strobe.  Stop another pop while
-        // its DPI staging register is pending, then let the approved primitive
-        // hold valid and payload through arbitrary RTL-side backpressure.
-        assign tx_req_model_ready[p] = tx_req_spill_ready[p] && !tx_req_valid_q[p];
-        assign tx_rsp_model_ready[p] = tx_rsp_spill_ready[p] && !tx_rsp_valid_q[p];
-        assign tx_req_flit_monitor = tx_req_flit[p];
-        assign tx_rsp_flit_monitor = tx_rsp_flit[p];
-
-        spill_register #(
-            .T(logic [REQ_FLIT_WIDTH-1:0]),
-            .Bypass(1'b0)
-        ) i_tx_req_spill_register (
-            .clk_i,
-            .rst_ni,
-            .valid_i(tx_req_valid_q[p]),
-            .ready_o(tx_req_spill_ready[p]),
-            .data_i(tx_req_flit_q[p]),
-            .valid_o(tx_req_valid[p]),
-            .ready_i(tx_req_ready[p]),
-            .data_o(tx_req_flit[p])
-        );
-
-        spill_register #(
-            .T(logic [RSP_FLIT_WIDTH-1:0]),
-            .Bypass(1'b0)
-        ) i_tx_rsp_spill_register (
-            .clk_i,
-            .rst_ni,
-            .valid_i(tx_rsp_valid_q[p]),
-            .ready_o(tx_rsp_spill_ready[p]),
-            .data_i(tx_rsp_flit_q[p]),
-            .valid_o(tx_rsp_valid[p]),
-            .ready_i(tx_rsp_ready[p]),
-            .data_o(tx_rsp_flit[p])
-        );
-
-        assert property (@(posedge clk_i) disable iff (!rst_ni)
-            tx_req_valid[p] && !tx_req_ready[p]
-            |=> tx_req_valid[p] && $stable(tx_req_flit_monitor))
-            else $error("router_wrap: REQ port %0d changed before handshake", p);
-
-        assert property (@(posedge clk_i) disable iff (!rst_ni)
-            tx_rsp_valid[p] && !tx_rsp_ready[p]
-            |=> tx_rsp_valid[p] && $stable(tx_rsp_flit_monitor))
-            else $error("router_wrap: RSP port %0d changed before handshake", p);
+        // Egress-hold checkers, written as explicit sampled-history registers
+        // rather than SVA $stable: under Verilator the $stable in a |=>
+        // consequent compares against a stale/initial $past sample, so the
+        // property false-fires on a port's FIRST backpressured cycle even
+        // while the wire provably holds (clocked trace vs $past=0, 2026-08-21
+        // hotspot mode-1 repro). The registers below sample at the same
+        // preponed edge an SVA would, on both Verilator and VCS.
+        logic chk_req_v_q, chk_req_r_q, chk_rsp_v_q, chk_rsp_r_q;
+        logic [REQ_FLIT_WIDTH-1:0] chk_req_flit_q;
+        logic [RSP_FLIT_WIDTH-1:0] chk_rsp_flit_q;
+        always_ff @(posedge clk_i) begin
+            chk_req_v_q    <= rst_ni && tx_req_valid[p];
+            chk_req_r_q    <= tx_req_ready[p];
+            chk_req_flit_q <= tx_req_flit[p];
+            chk_rsp_v_q    <= rst_ni && tx_rsp_valid[p];
+            chk_rsp_r_q    <= tx_rsp_ready[p];
+            chk_rsp_flit_q <= tx_rsp_flit[p];
+            if (rst_ni && chk_req_v_q && !chk_req_r_q &&
+                (!tx_req_valid[p] || tx_req_flit[p] !== chk_req_flit_q))
+                $error("router_wrap: REQ port %0d changed before handshake", p);
+            if (rst_ni && chk_rsp_v_q && !chk_rsp_r_q &&
+                (!tx_rsp_valid[p] || tx_rsp_flit[p] !== chk_rsp_flit_q))
+                $error("router_wrap: RSP port %0d changed before handshake", p);
+        end
     end
 
     assign tx_dat_valid    = tx_dat_valid_q;

--- a/sim/tb/noc_tb_top.sv
+++ b/sim/tb/noc_tb_top.sv
@@ -255,8 +255,9 @@ module noc_tb_top #(
         // dat_num_vc is printed rather than derived by the reader: it comes from
         // specgen/source/constants.yaml and no longer appears in the config name,
         // so the log is the only place it is bound to the run that used it.
-        $display("[Config] max_unique_ids=%0d max_outstanding=%0d dat_num_vc=%0d",
-                 max_unique_ids, max_outstanding, DAT_NUM_VC);
+        $display("[Config] max_unique_ids=%0d max_outstanding=%0d dat_num_vc=%0d router_vc_depth=%0d",
+                 max_unique_ids, max_outstanding, DAT_NUM_VC,
+                 ni_params_pkg::NOC_ROUTER_VC_DEPTH_DFLT);
         void'($value$plusargs("b_rob_depth=%d", b_rob_depth));
         void'($value$plusargs("r_rob_depth=%d", r_rob_depth));
         void'($value$plusargs("max_txns_per_id=%d", max_txns_per_id));

--- a/sim/tools/emit_result_csv.py
+++ b/sim/tools/emit_result_csv.py
@@ -24,7 +24,8 @@ _MON = re.compile(
     re.I,
 )
 _CONFIG = re.compile(
-    r"\[Config\]\s+max_unique_ids=(\d+)\s+max_outstanding=(\d+)\s+dat_num_vc=(\d+)")
+    r"\[Config\]\s+max_unique_ids=(\d+)\s+max_outstanding=(\d+)\s+dat_num_vc=(\d+)"
+    r"(?:\s+router_vc_depth=(\d+))?")
 
 
 def parse_monitors(log_text):
@@ -60,6 +61,7 @@ def parse_config(log_text, cli_max_unique_ids, cli_max_outstanding):
         cli_max_unique_ids if cli_max_unique_ids is not None else m.group(1),
         cli_max_outstanding if cli_max_outstanding is not None else m.group(2),
         int(m.group(3)),
+        int(m.group(4)) if m.group(4) else None,
     )
 
 
@@ -75,16 +77,23 @@ def main():
     ap.add_argument("--seed", required=True)
     ap.add_argument("--max-unique-ids", default=None)
     ap.add_argument("--max-outstanding", default=None)
+    # The next three do not appear in the tb [Config] line; unset means the run
+    # used the generator / ni_params_pkg default, which is what gets recorded.
+    ap.add_argument("--max-txns-per-id", default="32")
+    ap.add_argument("--ids-per-initiator", default="1")
+    ap.add_argument("--burst-len", default="0")
+    ap.add_argument("--space", default="memory")
     a = ap.parse_args()
 
     log_text = pathlib.Path(a.log).read_text()
     bw, latency = parse_monitors(log_text)
-    max_unique_ids, max_outstanding, dat_num_vc = parse_config(
+    max_unique_ids, max_outstanding, dat_num_vc, router_vc_depth = parse_config(
         log_text, a.max_unique_ids, a.max_outstanding
     )
     row = {
         "topology": a.topology,
         "vc": dat_num_vc,
+        "router_vc_depth": router_vc_depth,
         "pattern": a.pattern,
         "injection_mode": a.injection_mode,
         "injection_rate": a.injection_rate,
@@ -92,6 +101,10 @@ def main():
         "seed": a.seed,
         "max_unique_ids": max_unique_ids,
         "max_outstanding": max_outstanding,
+        "max_txns_per_id": a.max_txns_per_id,
+        "ids_per_initiator": a.ids_per_initiator,
+        "burst_len": a.burst_len,
+        "space": a.space,
         "accepted_bits_per_cycle": f"{bw:.1f}",
         "mean_latency": f"{latency:.1f}",
     }

--- a/sim/tools/gen_test_patterns.py
+++ b/sim/tools/gen_test_patterns.py
@@ -161,7 +161,7 @@ def _ax_fields(axid, addr, axi_len, axi_size, include_atop, user=0):
 def emit_file_master_node(out_dir, src_idx, dst_bases, n_nodes,
                           base_local, region_bytes, axi_size, axi_len, data_width,
                           id_rng, ids_per_initiator=1, num_axi_ids=256,
-                          extra=None):
+                          extra=None, wrap_window=None):
     """Write out_dir/{write,read}.txt for one node. One write+read pair per entry of
     dst_bases, src-partitioned address, address-in-data payload. INCR, atop=0,
     full strobe.
@@ -193,8 +193,16 @@ def emit_file_master_node(out_dir, src_idx, dst_bases, n_nodes,
     id_base = (src_idx * ids_per_initiator) % num_axi_ids
     write_lines, read_lines = [], []
     for seq, dst_base in enumerate(dst_bases):
-        local_off = alloc_unique_offset(dst_base, src_idx, seq, base_local,
-                                        n_nodes, region_bytes, reserved=reserved)
+        if wrap_window is not None:
+            # Config-space narrow traffic: the 4 KB aperture cannot hold one
+            # unique slot per (src, seq), so slots wrap inside the window and
+            # addresses repeat (see --space help: measurement modes only).
+            stride = max(_SLOT_STRIDE, reserved)
+            local_off = base_local + \
+                (src_idx * stride + seq * (n_nodes * stride)) % wrap_window
+        else:
+            local_off = alloc_unique_offset(dst_base, src_idx, seq, base_local,
+                                            n_nodes, region_bytes, reserved=reserved)
         addr = dst_base + local_off
         # Uniform over the tile's block, reuse allowed: axi_test.sv:233 draws
         # ax_id over the whole space and axi_rand_master's UNIQUE_IDS defaults
@@ -1060,6 +1068,13 @@ def main(argv=None):
                          "node ids: every tile draws from the peripheral endpoints, "
                          "the many-to-one shape a memory controller sees")
     # Synthetic payload shape
+    ap.add_argument("--space", choices=("memory", "config"), default="memory",
+                    help="Destination address space. memory = data class (DAT "
+                         "network). config = narrow class (REQ/RSP network, "
+                         "AxSIZE <= 3): offsets wrap inside the 4 KB config "
+                         "aperture, so addresses repeat and write-readback "
+                         "uniqueness does NOT hold -- measurement modes only, "
+                         "scoreboard-armed runs will miscompare")
     ap.add_argument("--size", type=int, default=2,
                     help="AxSIZE for synthetic transactions (0..7; default 2 = 4 bytes)")
     ap.add_argument("--len", type=int, default=0, dest="burst_len",
@@ -1106,10 +1121,31 @@ def main(argv=None):
     # readback of the same address agrees, so the run passes having delivered
     # every peripheral transaction to the wrong place.
     smallest_window = min(list(sizes["memory"].values()) + [p["size"] for p in peripherals])
-    if base_local + extent > smallest_window:
+    if a.space == "memory" and base_local + extent > smallest_window:
         ap.error(f"footprint base_local({base_local:#x}) + extent({extent:#x}) = "
                  f"{base_local + extent:#x} overruns the smallest addressable window "
                  f"{smallest_window:#x}; reduce --transactions-per-node, --len, or --size")
+    wrap_window = None
+    if a.space == "config":
+        if a.pattern == "multicast" or a.hotspot_peripherals:
+            ap.error("--space config supports the unicast patterns only "
+                     "(config-space multicast has its own machinery; "
+                     "peripherals own no config tile)")
+        if a.size > 3:
+            ap.error("--space config is the narrow class: AxSIZE <= 3 "
+                     "(8 B lane; S2 design doc sec 1)")
+        missing = [cid for (_i, _x, _y, cid) in nodes if cid not in config_bases]
+        if missing:
+            ap.error(f"--space config: topology {a.topology} declares no config "
+                     f"tile for cid(s) {missing}")
+        # Pattern slots live in [0x10, _CONFIG_PROBE_BASE), between the
+        # multicast slot and the cross-node probe window (layout table above).
+        base_local = 0x10
+        config_stride = max(_SLOT_STRIDE, burst_footprint)
+        wrap_window = ((_CONFIG_PROBE_BASE - base_local) // config_stride) * config_stride
+        if wrap_window == 0:
+            ap.error(f"burst footprint {burst_footprint:#x} does not fit the "
+                     f"config-aperture slot window; reduce --len or --size")
     rng = _random_module.Random(a.seed)
     # Ids draw from their own stream, so changing --ids-per-initiator moves the
     # ids and nothing else. Sharing `rng` would shift every later destination
@@ -1161,16 +1197,17 @@ def main(argv=None):
         # shares its host router's coordinate, so a coordinate no longer names
         # one destination and bases[cid] would send a peripheral's traffic to
         # that router's tile.
+        space_bases = config_bases if a.space == "config" else bases
         if a.pattern in _DETERMINISTIC_PATTERNS:
             dst_x, dst_y = _dst_for(a.pattern, x, y, x_dim, y_dim)
-            dst_bases = [bases[cid_of[(dst_x, dst_y)]]] * a.transactions_per_node
+            dst_bases = [space_bases[cid_of[(dst_x, dst_y)]]] * a.transactions_per_node
         elif a.pattern == "uniform_random":
             dst_lin = uniform_random_dsts(idx, n_nodes, a.transactions_per_node,
                                           rng, a.exclude_self)
-            dst_bases = [bases[cid_of[_linear_to_coord(d, x_dim)]] for d in dst_lin]
+            dst_bases = [space_bases[cid_of[_linear_to_coord(d, x_dim)]] for d in dst_lin]
         elif a.pattern == "all_to_all":
             dst_lin = all_to_all_dsts(idx, n_nodes, a.transactions_per_node)
-            dst_bases = [bases[cid_of[_linear_to_coord(d, x_dim)]] for d in dst_lin]
+            dst_bases = [space_bases[cid_of[_linear_to_coord(d, x_dim)]] for d in dst_lin]
         elif a.hotspot_peripherals:  # hotspot, on the boundary ports
             dst_bases = [p["base"] for p in
                          peripheral_hotspot_dsts(idx, peripherals, a.transactions_per_node,
@@ -1180,13 +1217,13 @@ def main(argv=None):
                 ap.error("--hotspot is required for the hotspot pattern")
             dst_lin = hotspot_dsts(idx, n_nodes, a.transactions_per_node, rng,
                                    a.hotspot, a.hotspot_rates, a.exclude_self)
-            dst_bases = [bases[cid_of[_linear_to_coord(d, x_dim)]] for d in dst_lin]
+            dst_bases = [space_bases[cid_of[_linear_to_coord(d, x_dim)]] for d in dst_lin]
         emit_file_master_node(os.path.join(a.out, f"node{idx}"), idx, dst_bases,
                               n_slots, base_local, region_bytes,
                               a.size, a.burst_len, widths["data"],
                               ids_per_initiator=a.ids_per_initiator,
                               num_axi_ids=(1 << widths["id"]), id_rng=id_rng,
-                              extra=extra)
+                              extra=extra, wrap_window=wrap_window)
 
 
 if __name__ == "__main__":

--- a/sim/tools/summarize_results.py
+++ b/sim/tools/summarize_results.py
@@ -1,0 +1,171 @@
+"""Summarize every run under sim/verilator/output/ as markdown tables.
+
+One parameter set = one section: a one-row parameter table, then a result
+table with one row per pattern (status + performance). Runs sharing a
+parameter set and pattern are averaged across seeds (n shown when > 1).
+
+Performance columns are filled from continuous (mode 1) runs only; a directed
+run is a closed-loop two-phase drain, so it contributes its scoreboard verdict
+and no latency/bandwidth.
+"""
+import csv
+import pathlib
+import re
+import sys
+from collections import defaultdict
+
+_PATTERNS = (
+    "neighbor", "transpose", "bit_complement", "bit_reverse", "shuffle",
+    "bit_rotation", "tornado", "uniform_random", "all_to_all", "hotspot",
+    "multicast",
+)
+_TAG = re.compile(
+    r"^(directed|checked|continuous)_(?P<config>.+)_(?P<pattern>" + "|".join(_PATTERNS) +
+    r")(?P<narrow>_narrow)?_(?:r(?P<rate>[\d.]+)_)?s(?P<seed>\d+)$")
+_CONFIG = re.compile(
+    r"\[Config\]\s+max_unique_ids=(\d+)\s+max_outstanding=(\d+)\s+dat_num_vc=(\d+)"
+    r"(?:\s+router_vc_depth=(\d+))?")
+_PASS = re.compile(r"PASS: all (\d+) nodes done, non-vacuous")
+
+_PARAM_COLS = ("topology", "vc", "router_depth", "outstanding", "txns_per_id",
+               "ids/init", "burst_len", "mode", "rate", "txns/node")
+
+
+def emit_table(header, rows):
+    widths = [max(len(h), *(len(r[i]) for r in rows)) for i, h in enumerate(header)]
+    line = lambda cells: "| " + " | ".join(c.ljust(w) for c, w in zip(cells, widths)) + " |"
+    print(line(header))
+    print("|" + "|".join("-" * (w + 2) for w in widths) + "|")
+    for r in rows:
+        print(line(r))
+    print()
+
+
+def collect(out_root):
+    """{param_tuple: {pattern: [run dict]}}, param_tuple ordered as _PARAM_COLS."""
+    groups = defaultdict(lambda: defaultdict(list))
+    for run_dir in sorted(p for p in out_root.iterdir() if p.is_dir()):
+        if run_dir.name.startswith("continuous_"):
+            csv_path = run_dir / "result.csv"
+            if not csv_path.exists():
+                # Aborted before the monitors reported: no CSV, so only the
+                # parameters in the tag and the [Config] line are known.
+                m = _TAG.match(run_dir.name)
+                log_path = run_dir / "run.log"
+                if not m or not log_path.exists():
+                    continue
+                cfg = _CONFIG.search(log_path.read_text())
+                key = (m.group("config"), cfg.group(3), cfg.group(4) or "?",
+                       cfg.group(2), "?", "?", "?", "continuous",
+                       m.group("rate") or "?", "?")
+                groups[key][m.group("pattern")].append({
+                    "status": "FAIL",
+                    "space": "config" if m.group("narrow") else "memory"})
+                continue
+            row = next(csv.DictReader(csv_path.open()))
+            mode = {"0": "directed", "1": "continuous", "2": "checked"}[
+                row["injection_mode"]]
+            key = (row["topology"], row["vc"],
+                   row.get("router_vc_depth") or "?",
+                   row["max_outstanding"], row.get("max_txns_per_id", "32"),
+                   row.get("ids_per_initiator", "1"), row.get("burst_len", "0"),
+                   mode, row["injection_rate"], row["injection_count"])
+            groups[key][row["pattern"]].append({
+                "status": "PASS (completed, no data check)",
+                "space": row.get("space", "memory"),
+                "bw": float(row["accepted_bits_per_cycle"]),
+                "latency": float(row["mean_latency"]),
+            })
+        else:
+            m = _TAG.match(run_dir.name)
+            log_path = run_dir / "run.log"
+            if not m or not log_path.exists():
+                continue
+            text = log_path.read_text()
+            cfg = _CONFIG.search(text)
+            key = (m.group("config"), cfg.group(3), cfg.group(4) or "?",
+                   cfg.group(2), "-", "-", "-", m.group(1),
+                   m.group("rate") or "-", "-")
+            groups[key][m.group("pattern")].append({
+                "status": "PASS (scoreboard)" if _PASS.search(text) else "FAIL",
+                "space": "config" if m.group("narrow") else "memory",
+            })
+    return groups
+
+
+# Shipped defaults, mirroring specgen/source/constants.yaml (DAT_NUM_VC,
+# NSU_META_BUFFER_*, NMU_MAX_TXNS_PER_ID) and the generator defaults.
+_DEFAULTS = {"vc": "2", "router_depth": "8", "outstanding": "32",
+             "txns_per_id": "32", "ids/init": "1", "burst_len": "0"}
+
+
+def group_label(key):
+    """Name a group by how it differs from the shipped defaults.
+    '?' fields (aborted run, value unrecorded) are excluded from the diff."""
+    diffs = [f"{col}={val}" for col, val in zip(_PARAM_COLS, key)
+             if col in _DEFAULTS and val not in ("?", "-")
+             and val != _DEFAULTS[col]]
+    if key[7] != "continuous":
+        diffs.append(f"mode={key[7]}")
+    if any(v == "?" for v in key):
+        diffs.append("aborted before reporting, unrecorded fields ?")
+    return ", ".join(diffs) if diffs else "default"
+
+
+def main():
+    out_root = pathlib.Path(sys.argv[1] if len(sys.argv) > 1 else
+                            "sim/verilator/output")
+    groups = collect(out_root)
+    labeled = sorted(
+        ((group_label(k), k) for k in groups),
+        key=lambda lk: (lk[1][7] != "continuous", "?" in lk[1],
+                        lk[0] != "default", lk[0]))
+
+    print("# Continuous-mode parameter sweep\n")
+    print("BW = accepted bits/cycle summed over every node monitor. "
+          "Latency = sample-weighted mean over read and write transactions. "
+          "One seed per cell. PASS (completed) means protocol checks, model "
+          "invariants and the watchdog stayed clean; the write-readback "
+          "scoreboard is armed only in directed and checked modes.\n\n"
+          "data = memory space, AxSIZE 5 (32 B/beat), DAT network. "
+          "narrow = config space, AxSIZE 3 (the 8 B lane), REQ/RSP network. "
+          "Same pattern, parameters and seed policy per row; bits/cycle is "
+          "not comparable across classes (lane widths differ by design), "
+          "latency is.\n")
+    for i, (label, key) in enumerate(labeled, 1):
+        patterns = groups[key]
+        print(f"## Set {i}: {label}\n")
+        emit_table(_PARAM_COLS, [key])
+        rows = []
+        has_narrow = any(r["space"] == "config"
+                         for runs in patterns.values() for r in runs)
+        for pattern in sorted(patterns):
+            runs = patterns[pattern]
+            data = [r for r in runs if r["space"] != "config"]
+            narrow = [r for r in runs if r["space"] == "config"]
+
+            def mean(rs, field):
+                ok = [r[field] for r in rs if field in r]
+                return sum(ok) / len(ok) if ok else None
+
+            flags = [f"{name} FAIL" for name, rs in (("data", data),
+                                                     ("narrow", narrow))
+                     if any(r["status"] == "FAIL" for r in rs)]
+            status = ", ".join(flags) if flags else runs[0]["status"]
+            dbw, dlat = mean(data, "bw"), mean(data, "latency")
+            nlat = mean(narrow, "latency")
+            delta = f"{nlat - dlat:+.1f}" if dlat is not None and \
+                nlat is not None else "-"
+            fmt = lambda v: f"{v:.1f}" if v is not None else "-"
+            row = [pattern, status, fmt(dbw), fmt(dlat)]
+            if has_narrow:
+                row += [fmt(nlat), delta]
+            rows.append(row)
+        header = ["pattern", "status", "data bits/cyc", "data lat (cyc)"]
+        if has_narrow:
+            header += ["narrow lat (cyc)", "narrow-data (cyc)"]
+        emit_table(header, rows)
+
+
+if __name__ == "__main__":
+    main()

--- a/sim/tools/test_gen_test_patterns_filemaster.py
+++ b/sim/tools/test_gen_test_patterns_filemaster.py
@@ -1130,3 +1130,47 @@ def test_hotspot_peripherals_weights_the_target_set(tmp_path):
                 if p["base"] <= t["addr"] < p["base"] + p["size"]:
                     counts[i] += 1
     assert counts[0] > sum(counts[1:]), counts
+
+
+# ---- --space config (narrow class) ----
+
+def test_space_config_targets_the_config_aperture(tmp_path):
+    """--space config swaps every destination window base from the memory
+    aperture to the 4 KB config aperture (narrow class, spec section 5): each
+    address must land inside [0x0200_0000, 0x0200_1000) of its node block."""
+    g.main(["--pattern", "neighbor", "--topology", "mesh_2x2",
+            "--out", str(tmp_path), "--transactions-per-node", "4",
+            "--size", "3", "--len", "0", "--seed", "1", "--space", "config"])
+    lines = (tmp_path / "node0" / "write.txt").read_text().splitlines()
+    addr = int(lines[1], 16)
+    local = addr & 0xFFFFFFFF
+    assert 0x02000000 <= local < 0x02001000
+
+
+def test_space_config_offsets_wrap_inside_the_slot_window(tmp_path):
+    """Config-space pattern slots live in [0x10, 0x800) and wrap: no offset may
+    reach the cross-node probe window at 0x800 or the mcast slot below 0x10,
+    however many transactions the run asks for."""
+    g.main(["--pattern", "neighbor", "--topology", "mesh_2x2",
+            "--out", str(tmp_path), "--transactions-per-node", "200",
+            "--size", "3", "--len", "0", "--seed", "1", "--space", "config"])
+    for i in range(4):
+        lines = (tmp_path / f"node{i}" / "write.txt").read_text().splitlines()
+        # The address is the only single-token 0x line _ax_fields emits (other
+        # header fields are decimal; a data-beat line carries three tokens).
+        addrs = [int(l, 16) for l in lines if re.fullmatch(r"0x[0-9a-f]+", l)]
+        assert addrs
+        for a in addrs:
+            # Pattern slots wrap in [0x10, 0x800); the per-pattern narrow
+            # probe extra legitimately sits at offset 0. Nothing may reach
+            # the cross-node probe window at 0x800.
+            assert (a & 0xFFF) < 0x800
+
+
+def test_space_config_rejects_a_wide_size(tmp_path):
+    """Narrow class is the 8 B lane: AxSIZE > 3 is a stimulus error, not a
+    truncation."""
+    with pytest.raises(SystemExit):
+        g.main(["--pattern", "neighbor", "--topology", "mesh_2x2",
+                "--out", str(tmp_path), "--transactions-per-node", "4",
+                "--size", "5", "--len", "0", "--space", "config"])

--- a/sim/tools/test_summarize_results.py
+++ b/sim/tools/test_summarize_results.py
@@ -1,0 +1,45 @@
+import sys
+
+import summarize_results as s
+
+
+def _write_csv(run_dir, pattern, seed, space="memory", vc="2", burst="0",
+               bw="100.0", lat="50.0"):
+    run_dir.mkdir(parents=True)
+    header = ("topology,vc,router_vc_depth,pattern,injection_mode,"
+              "injection_rate,injection_count,seed,max_unique_ids,"
+              "max_outstanding,max_txns_per_id,ids_per_initiator,burst_len,"
+              "space,accepted_bits_per_cycle,mean_latency")
+    row = (f"mesh_2x2,{vc},8,{pattern},1,0.9,200,{seed},1,32,32,1,{burst},"
+           f"{space},{bw},{lat}")
+    (run_dir / "result.csv").write_text(header + "\n" + row + "\n")
+
+
+def test_default_and_diff_labels(tmp_path, capsys, monkeypatch):
+    _write_csv(tmp_path / "continuous_mesh_2x2_neighbor_r0.9_s1", "neighbor", 1)
+    _write_csv(tmp_path / "continuous_mesh_2x2_neighbor_r0.9_s2", "neighbor", 2,
+               vc="8", burst="32")
+    monkeypatch.setattr(sys, "argv", ["summarize_results", str(tmp_path)])
+    s.main()
+    out = capsys.readouterr().out
+    # The all-defaults group is named "default" and sorts first; the other
+    # group is named by its diffs against the shipped defaults.
+    assert "## Set 1: default" in out
+    assert "## Set 2: vc=8, burst_len=32" in out
+    assert "| neighbor" in out
+
+
+def test_narrow_runs_add_the_latency_compare_columns(tmp_path, capsys,
+                                                     monkeypatch):
+    _write_csv(tmp_path / "continuous_mesh_2x2_neighbor_r0.9_s1", "neighbor", 1,
+               lat="50.0")
+    _write_csv(tmp_path / "continuous_mesh_2x2_neighbor_narrow_r0.9_s2",
+               "neighbor", 2, space="config", lat="40.0")
+    monkeypatch.setattr(sys, "argv", ["summarize_results", str(tmp_path)])
+    s.main()
+    out = capsys.readouterr().out
+    # Same parameter set, both classes: one row with data and narrow columns
+    # and their difference. Without any narrow run those columns are omitted
+    # (test_default_and_diff_labels' output has no such header).
+    assert "narrow lat (cyc)" in out
+    assert "-10.0" in out

--- a/sim/verilator/Makefile
+++ b/sim/verilator/Makefile
@@ -300,6 +300,14 @@ IDS_PER_INITIATOR ?=
 # At --size 5 (32 B/beat), 63 gives 64 beats = 2048 B, inside the 4 KB boundary.
 BURST_LEN       ?= 0
 
+# Destination address space for generated stimulus (gen_test_patterns --space).
+# memory = data class (DAT network, AxSIZE 5). config = narrow class (REQ/RSP
+# network, AxSIZE 3 = the 8 B lane); config-space offsets wrap inside the 4 KB
+# aperture, so it is for measurement modes only -- scoreboard-armed runs
+# miscompare.
+SPACE           ?= memory
+STIM_SIZE       ?= $(if $(filter config,$(SPACE)),3,5)
+
 # Per-AXI-ID order-list depth (FlooNoC MaxRoTxnsPerId, floo_rob.sv:12). No ?=
 # default; see B_ROB_DEPTH note above.
 
@@ -310,7 +318,7 @@ _CONTINUOUS    := $(filter 1,$(INJECTION_MODE))
 _CHECKED       := $(filter 2,$(INJECTION_MODE))
 # Pattern tag: multicast runs are per-shape, so the shape joins the stim dir /
 # output tag (row and submesh runs must not share stimulus or logs).
-_PATTERN_TAG   := $(PATTERN)$(if $(filter multicast,$(PATTERN)),_$(MCAST_SHAPE))
+_PATTERN_TAG   := $(PATTERN)$(if $(filter multicast,$(PATTERN)),_$(MCAST_SHAPE))$(if $(filter config,$(SPACE)),_narrow)
 # DMA=1 replaces the pattern stimulus with iDMA job files, so its stimulus and
 # its run tag key on the job geometry rather than on PATTERN / INJECTION_COUNT,
 # neither of which a DMA run reads.
@@ -354,7 +362,8 @@ gen:
 	@mkdir -p $(STIM_ROOT)
 	$(if $(filter 1,$(DMA)),,$(PYTHON3) $(GEN_PATTERNS) --topology $(CONFIG) \
 	    --out $(STIM_ROOT) --pattern $(PATTERN) \
-	    --transactions-per-node $(INJECTION_COUNT) --size 5 --len $(BURST_LEN) \
+	    --transactions-per-node $(INJECTION_COUNT) --size $(STIM_SIZE) --len $(BURST_LEN) \
+	    $(if $(filter config,$(SPACE)),--space config) \
 	    --seed $(SEED) $(_HOTSPOT_ARGS) $(_MCAST_ARGS) \
 	    $(if $(IDS_PER_INITIATOR),--ids-per-initiator $(IDS_PER_INITIATOR)))
 	$(if $(filter 1,$(DMA)),$(PYTHON3) $(GEN_DMA_JOBS) --topology $(CONFIG) \
@@ -425,7 +434,10 @@ sim run: $(if $(filter run,$(MAKECMDGOALS)),check-built,$(TBTOP_EXE))
 	        --injection-mode $(INJECTION_MODE) --injection-rate $(INJECTION_RATE) \
 	        --injection-count $(INJECTION_COUNT) --seed $(SEED) \
 	        $(if $(MAX_UNIQUE_IDS),--max-unique-ids $(MAX_UNIQUE_IDS)) \
-	        $(if $(MAX_OUTSTANDING),--max-outstanding $(MAX_OUTSTANDING)); \
+	        $(if $(MAX_OUTSTANDING),--max-outstanding $(MAX_OUTSTANDING)) \
+	        $(if $(MAX_TXNS_PER_ID),--max-txns-per-id $(MAX_TXNS_PER_ID)) \
+	        $(if $(IDS_PER_INITIATOR),--ids-per-initiator $(IDS_PER_INITIATOR)) \
+	        --burst-len $(BURST_LEN) --space $(SPACE); \
 	    echo "CONTINUOUS PASS: $(SIM_TAG)"; \
 	elif [ $$rc -ne 0 ] || ! grep -q 'PASS: all' output/$(SIM_TAG)/run.log; then \
 	    echo "DIRECTED FAIL: run did not reach non-vacuous PASS (rc=$$rc)"; exit 1; \


### PR DESCRIPTION
## Summary
- **fix(router)**: per-VC wormhole arbiter locking, queues and grant scan. Root cause of the uniform_random multi-beat abort: DatMergeWrap's stream-level lock let one worm's tail release another VC's mid-flight worm, admitting NSU DataR into its beat stream. Per-(input, VC) pending queues also remove a cross-VC head-of-line deadlock, and the grant scan skips downstream-refused candidates instead of retrying them forever (credit livelock). Single-VC faces keep their previous behavior bit for bit. 4 new unit tests, one per failure shape.
- **fix(sim)**: REQ/RSP egress restaged from valid_q + spill_register to a single hold register in all three DPI wraps. The spill stage halved REQ/RSP link throughput and exactly cancelled the SimpleRouter's one-stage-per-hop advantage over the DAT credit router (zero-load narrow read now measures 44 vs 52 cyc for data). Egress-hold SVAs become explicit sampled-history checkers: Verilator's $stable in a |=> consequent compares against a stale $past sample and false-fires on a port's first backpressured cycle.
- **feat(sim)**: `gen_test_patterns --space config` aims a pattern at the 4 KB config aperture (narrow class, AxSIZE <= 3, measurement modes only); result.csv gains router_vc_depth, max_txns_per_id, ids_per_initiator, burst_len and space columns.
- **feat(tools)**: `sim/tools/summarize_results.py` renders run directories as one markdown report, one section per parameter set.

## Testing
- On this base: ctest 672/672, sim/tools pytest 108/108, specgen drift gate clean.
- Co-sim regression on the pre-divergence base (Verilator/WSL): directed scoreboard runs plus mode-1 neighbor/transpose/hotspot/uniform_random, including the first-ever pass of uniform_random x 33-beat bursts, with the egress-hold checkers armed throughout.
- Pre-existing, unrelated: origin/main's Verilator tb does not elaborate (noc_tb_top.sv:333 still passes ID_WIDTH to user_node_endpoint, renamed in #57), so co-sim could not be re-run on this exact base.

🤖 Generated with [Claude Code](https://claude.com/claude-code)