### PR TITLE
fix(sim): follow user_node_endpoint id-width rename in noc_tb_top

### DIFF
--- a/sim/tb/noc_tb_top.sv
+++ b/sim/tb/noc_tb_top.sv
@@ -330,7 +330,9 @@ module noc_tb_top #(
     for (genvar i = 0; i < NUM_ENDPOINTS; i++) begin : g_endpoint
         user_node_endpoint #(
             .NODE_ID(i),
-            .ID_WIDTH(ID_WIDTH), .ADDR_WIDTH(ADDR_WIDTH), .DATA_WIDTH(DATA_WIDTH),
+            // #57 split the endpoint's id width into AXI (external, its own
+            // ni_params default) and NOC (this tb's ID_WIDTH knob).
+            .NOC_ID_WIDTH(ID_WIDTH), .ADDR_WIDTH(ADDR_WIDTH), .DATA_WIDTH(DATA_WIDTH),
             .TILE_TARGETS(TILE_TARGETS), .TILE_BASE_ADDR(TILE_BASE_ADDR[i]),
             .TILE_SIZE(TILE_SIZE[i]), .NOC_EGRESS_BASE(NOC_EGRESS_BASE),
             .MEM_STALL_RANDOM_INPUT(MEM_STALL_RANDOM_INPUT),


### PR DESCRIPTION
PR #57 renamed user_node_endpoint's ID_WIDTH parameter into AXI_ID_WIDTH + NOC_ID_WIDTH; noc_tb_top.sv:333 still passed the old name, so the Verilator co-sim testbench stopped elaborating on main (unnoticed: the docker flow does not build this path). One-line pin rename; the tb's ID_WIDTH knob threads to the endpoint's NoC side and the external AXI side keeps its ni_params default.

Verified on this base: Verilator build clean, directed neighbor scoreboard PASS, mode-1 uniform_random x 33-beat burst PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)