### PR TITLE
feat(sim): continuous run class with an ideal master-face profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ split).
 | mode | shape | checking |
 |---|---|---|
 | `0` (default) | two-phase: writes drain, then reads | scoreboard armed |
-| `1` | continuous: reads and writes interleave, both paced per cycle by `INJECTION_RATE` (0.0 to 1.0) | scoreboard disarmed (write-before-read fails); bandwidth monitor gates, `result.csv` emitted |
+| `1` | continuous: reads and writes interleave, both paced per cycle by `INJECTION_RATE` (0.0 to 1.0). Builds the `continuous` run class, whose master-face backpressure profile is ideal so the consumer never throttles the measurement (modes 0 and 2 keep the random profile) | scoreboard disarmed (write-before-read fails); bandwidth monitor gates, `result.csv` emitted |
 | `2` | checked-continuous: writes paced as mode 1, each read issues after its paired write's B response | scoreboard armed |
 
 Mode 1 measures bandwidth and latency without data checking. Mode 2

--- a/sim/tb/noc_tb_top.sv
+++ b/sim/tb/noc_tb_top.sv
@@ -255,9 +255,9 @@ module noc_tb_top #(
         // dat_num_vc is printed rather than derived by the reader: it comes from
         // specgen/source/constants.yaml and no longer appears in the config name,
         // so the log is the only place it is bound to the run that used it.
-        $display("[Config] max_unique_ids=%0d max_outstanding=%0d dat_num_vc=%0d router_vc_depth=%0d",
+        $display("[Config] max_unique_ids=%0d max_outstanding=%0d dat_num_vc=%0d router_vc_depth=%0d mst_stall_random=%0d",
                  max_unique_ids, max_outstanding, DAT_NUM_VC,
-                 ni_params_pkg::NOC_ROUTER_VC_DEPTH_DFLT);
+                 ni_params_pkg::NOC_ROUTER_VC_DEPTH_DFLT, MST_STALL_RANDOM_OUTPUT);
         void'($value$plusargs("b_rob_depth=%d", b_rob_depth));
         void'($value$plusargs("r_rob_depth=%d", r_rob_depth));
         void'($value$plusargs("max_txns_per_id=%d", max_txns_per_id));

--- a/sim/tb/tb_noc_mesh.sv
+++ b/sim/tb/tb_noc_mesh.sv
@@ -12,7 +12,14 @@
 //
 // The module is named tb_top so --top-module needs no per-configuration value.
 
-module tb_top;
+module tb_top #(
+    // Master-face backpressure profile: 1 = "random" (the file master
+    // sometimes cannot keep up, so R backs up through the tile crossbar into
+    // the NMU -- the stress that makes the RoB fill), the directed run class.
+    // The continuous run class (sim/verilator/Makefile RUN_CLASS) builds with
+    // 0 = "ideal": a measurement run must not be throttled by its own consumer.
+    parameter bit MST_STALL_RANDOM_OUTPUT = 1'b1
+);
 
     import topology_pkg::*;
 
@@ -23,11 +30,6 @@ module tb_top;
     localparam bit          MEM_STALL_RANDOM_OUTPUT = 1'b0;
     localparam int unsigned MEM_FIXED_DELAY_INPUT   = 0;
     localparam int unsigned MEM_FIXED_DELAY_OUTPUT  = 0;
-    // Master-face backpressure profile "random": the file master sometimes
-    // cannot keep up, so R backs up through the tile crossbar into the NMU,
-    // which is what makes the RoB fill and the DAT dependency question
-    // reachable at all.
-    localparam bit          MST_STALL_RANDOM_OUTPUT = 1'b1;
     localparam int unsigned MST_FIXED_DELAY_OUTPUT  = 0;
 
     noc_tb_top #(

--- a/sim/tools/emit_result_csv.py
+++ b/sim/tools/emit_result_csv.py
@@ -25,7 +25,7 @@ _MON = re.compile(
 )
 _CONFIG = re.compile(
     r"\[Config\]\s+max_unique_ids=(\d+)\s+max_outstanding=(\d+)\s+dat_num_vc=(\d+)"
-    r"(?:\s+router_vc_depth=(\d+))?")
+    r"(?:\s+router_vc_depth=(\d+))?(?:\s+mst_stall_random=(\d+))?")
 
 
 def parse_monitors(log_text):
@@ -62,6 +62,7 @@ def parse_config(log_text, cli_max_unique_ids, cli_max_outstanding):
         cli_max_outstanding if cli_max_outstanding is not None else m.group(2),
         int(m.group(3)),
         int(m.group(4)) if m.group(4) else None,
+        int(m.group(5)) if m.group(5) else None,
     )
 
 
@@ -87,7 +88,7 @@ def main():
 
     log_text = pathlib.Path(a.log).read_text()
     bw, latency = parse_monitors(log_text)
-    max_unique_ids, max_outstanding, dat_num_vc, router_vc_depth = parse_config(
+    max_unique_ids, max_outstanding, dat_num_vc, router_vc_depth, mst_stall_random = parse_config(
         log_text, a.max_unique_ids, a.max_outstanding
     )
     row = {
@@ -105,6 +106,7 @@ def main():
         "ids_per_initiator": a.ids_per_initiator,
         "burst_len": a.burst_len,
         "space": a.space,
+        "mst_stall_random": mst_stall_random,
         "accepted_bits_per_cycle": f"{bw:.1f}",
         "mean_latency": f"{latency:.1f}",
     }

--- a/sim/tools/summarize_results.py
+++ b/sim/tools/summarize_results.py
@@ -25,11 +25,11 @@ _TAG = re.compile(
     r")(?P<narrow>_narrow)?_(?:r(?P<rate>[\d.]+)_)?s(?P<seed>\d+)$")
 _CONFIG = re.compile(
     r"\[Config\]\s+max_unique_ids=(\d+)\s+max_outstanding=(\d+)\s+dat_num_vc=(\d+)"
-    r"(?:\s+router_vc_depth=(\d+))?")
+    r"(?:\s+router_vc_depth=(\d+))?(?:\s+mst_stall_random=(\d+))?")
 _PASS = re.compile(r"PASS: all (\d+) nodes done, non-vacuous")
 
 _PARAM_COLS = ("topology", "vc", "router_depth", "outstanding", "txns_per_id",
-               "ids/init", "burst_len", "mode", "rate", "txns/node")
+               "ids/init", "burst_len", "mode", "rate", "txns/node", "mst_stall")
 
 
 def emit_table(header, rows):
@@ -73,7 +73,7 @@ def collect(out_root):
                 cfg = _CONFIG.search(log_path.read_text())
                 key = (m.group("config"), cfg.group(3), cfg.group(4) or "?",
                        cfg.group(2), "?", "?", "?", "continuous",
-                       m.group("rate") or "?", "?")
+                       m.group("rate") or "?", "?", cfg.group(5) or "?")
                 groups[key][m.group("pattern")].append({
                     "status": "FAIL",
                     "space": "config" if m.group("narrow") else "memory"})
@@ -86,7 +86,8 @@ def collect(out_root):
                    row.get("router_vc_depth") or "?",
                    row["max_outstanding"], row.get("max_txns_per_id", "32"),
                    row.get("ids_per_initiator", "1"), row.get("burst_len", "0"),
-                   mode, row["injection_rate"], row["injection_count"])
+                   mode, row["injection_rate"], row["injection_count"],
+                   row.get("mst_stall_random") or "-")
             groups[key][row["pattern"]].append({
                 "status": "PASS (completed, no data check)",
                 "space": row.get("space", "memory"),
@@ -103,7 +104,7 @@ def collect(out_root):
             cfg = _CONFIG.search(text)
             key = (m.group("config"), cfg.group(3), cfg.group(4) or "?",
                    cfg.group(2), "-", "-", "-", m.group(1),
-                   m.group("rate") or "-", "-")
+                   m.group("rate") or "-", "-", cfg.group(5) or "-")
             groups[key][m.group("pattern")].append({
                 "status": "PASS (scoreboard)" if _PASS.search(text) else "FAIL",
                 "space": "config" if m.group("narrow") else "memory",

--- a/sim/verilator/Makefile
+++ b/sim/verilator/Makefile
@@ -23,10 +23,16 @@ PYTHON3 ?= python3
 CONFIG ?= mesh_4x4
 
 # Run class selects the endpoint/checking flavor compiled into the binary:
-#   directed (only) : file_master + scoreboard, INCR two-phase.
-RUN_CLASS ?= directed
-ifeq ($(filter $(RUN_CLASS),directed),)
-$(error RUN_CLASS must be directed (got '$(RUN_CLASS)'))
+#   directed   : file_master + scoreboard; master-face backpressure profile
+#                "random" (tb_noc_mesh.sv MST_STALL_RANDOM_OUTPUT = 1), the
+#                stress that fills the RoB.
+#   continuous : same endpoint with the "ideal" master-face profile -- a
+#                measurement run must not be throttled by its own consumer
+#                (measured: the random profile hid 4x of neighbor bandwidth).
+#                Selected by INJECTION_MODE=1; each class has its own obj_dir.
+RUN_CLASS ?= $(if $(filter 1,$(INJECTION_MODE)),continuous,directed)
+ifeq ($(filter $(RUN_CLASS),directed continuous),)
+$(error RUN_CLASS must be directed or continuous (got '$(RUN_CLASS)'))
 endif
 
 # Build environment config and include dirs are shared with sim/vcs/Makefile
@@ -135,7 +141,8 @@ VERILATOR_FLAGS := \
     --timing \
     --Mdir $(OBJ_DIR) \
     -CFLAGS "-g" \
-    -CFLAGS "-O0"
+    -CFLAGS "-O0" \
+    $(if $(filter continuous,$(RUN_CLASS)),-GMST_STALL_RANDOM_OUTPUT=0)
 
 # Optional strict-mode flag injection for release gates.
 # Override with: make VERILATOR_EXTRA_FLAGS="--Wall --Wpedantic"
@@ -395,7 +402,7 @@ sim run: $(if $(filter run,$(MAKECMDGOALS)),check-built,$(TBTOP_EXE))
 	# before a vacuous no-scoreboard run. Deliberately a recipe check, not a
 	# parse-time $(error): OBJ_DIR/TBTOP_EXE are := fixed at parse, so a target-
 	# specific override cannot re-key them; the cost is a wasted wrong-flavor build.
-	@[ "$(RUN_CLASS)" = "directed" ] || { echo "ERROR: a run requires RUN_CLASS=directed (got '$(RUN_CLASS)')"; exit 1; }
+	@[ "$(RUN_CLASS)" = "$(if $(filter 1,$(INJECTION_MODE)),continuous,directed)" ] || { echo "ERROR: INJECTION_MODE=$(INJECTION_MODE) runs on RUN_CLASS=$(if $(filter 1,$(INJECTION_MODE)),continuous,directed) (got '$(RUN_CLASS)')"; exit 1; }
 	@mkdir -p output/$(SIM_TAG)
 	@echo ">>> $@ CONFIG=$(CONFIG) PATTERN=$(PATTERN) SEED=$(SEED)"
 	@echo "running $(SIM_TAG) (mode=$(INJECTION_MODE) rate=$(INJECTION_RATE) count=$(INJECTION_COUNT) pattern=$(PATTERN))"
@@ -461,10 +468,10 @@ sim run: $(if $(filter run,$(MAKECMDGOALS)),check-built,$(TBTOP_EXE))
 # step measures what other settings would buy, and reports it as a number.
 SWEEP_RATES ?= 0.05 0.1 0.2 0.3 0.4 0.5 0.7 0.85 1.0
 
-# Set tools/gen_tb_top.py's _MST_BACKPRESSURE to "ideal" before running this,
-# and put it back afterwards. The default is "random", which stalls the master's
-# R and B channels, and a consumer that stalls first is what the curve then
-# measures instead of fabric saturation. Same reason _MEM_LATENCY stays "ideal".
+# INJECTION_MODE=1 selects the continuous run class, whose binary carries the
+# ideal master-face backpressure profile, so the curve measures the fabric and
+# not a consumer that stalls first (tools/gen_tb_top.py's _MST_BACKPRESSURE
+# governs the DMA top only). Same reason _MEM_LATENCY stays "ideal".
 # Generate once, up front: every point in the loop below runs the same
 # configuration, so one generation covers all of them.
 .PHONY: sim-injection-sweep


### PR DESCRIPTION
The mesh tb hardcoded the random master-face backpressure profile, so every mode-1 measurement was throttled by its own consumer. Per-stage decomposition of a read on mesh_4x4 neighbor with 33-beat bursts: request path 11 cycles, fabric transit 10 cycles, then ~10,400 cycles between the data reaching the NMU and the stalled master draining it. With the profile ideal the same run measures 5881 bits/cyc instead of 1410 and DAT link utilization 0.69 instead of 0.17.

INJECTION_MODE=1 now selects the continuous run class (own obj_dir, -GMST_STALL_RANDOM_OUTPUT=0); modes 0 and 2 keep the random profile, the stress that fills the RoB. tb_top takes the profile as a parameter, the tb [Config] line records it, result.csv and the summary carry it as mst_stall. The injection-sweep note no longer points at gen_tb_top.py, which governs the DMA top only.

Verified: directed neighbor scoreboard PASS with mst_stall_random=1, continuous neighbor PASS with mst_stall_random=0 (separate obj_dirs), sim/tools pytest 108/108.

🤖 Generated with [Claude Code](https://claude.com/claude-code)